### PR TITLE
Representative image

### DIFF
--- a/pages/api/facet/[label]/[value].ts
+++ b/pages/api/facet/[label]/[value].ts
@@ -17,6 +17,7 @@ export default function handler(request, response) {
       id: item.id,
       type: "Manifest",
       label: item.label,
+      thumbnail: item.thumbnail,
       homepage: [
         {
           id: `${origin}/works/${item.slug}`,

--- a/services/build/canopy.js
+++ b/services/build/canopy.js
@@ -6,6 +6,7 @@ const { log } = require("./log");
 const { getRootCollection, getBulkManifests } = require("./request");
 const { buildIndexData } = require("./search");
 const { buildFacets } = require("./facets");
+const { getRepresentativeImage } = require("../iiif/image")
 
 module.exports.build = (env) => {
   const canopyDirectory = ".canopy";
@@ -42,28 +43,41 @@ module.exports.build = (env) => {
     const canopyManifests = canopyCollection.items
       .filter((item) => item.type === "Manifest")
       .map((item, index) => {
-        const slug = getSlug(getLabel(item.label)[0]);
         return {
           collectionId: item.parent,
           id: item.id,
           index: index,
           label: item.label,
-          slug: slug,
-          thumbnail: item.thumbnail? item.thumbnail : [],
         };
       });
 
-    fs.writeFile(
-      `${canopyDirectory}/manifests.json`,
-      JSON.stringify(canopyManifests),
-      (err) => {
-        if (err) {
-          console.error(err);
-        }
-      }
-    );
-
     const responses = getBulkManifests(canopyManifests, 10);
+
+    responses
+      .then((manifests) => {
+        const allManifests = manifests.map((manifest, index) => {
+          // Break this into a function / service
+          const thumbnail = manifest.thumbnail? manifest.thumbnail : (
+            manifest.items[0].thumbnail? manifest.items[0].thumbnail : (
+              getRepresentativeImage(manifest, 400)? getRepresentativeImage(manifest, 400) : []
+            )
+          );
+          return {
+            ...canopyManifests.find(canopyManifest => canopyManifest.id === manifest.id),
+            slug: getSlug(getLabel(manifest.label).shift()),
+            thumbnail: thumbnail,
+          }
+        })
+        fs.writeFile(
+          `${canopyDirectory}/manifests.json`,
+          JSON.stringify(allManifests),
+          (err) => {
+            if (err) {
+              console.error(err);
+            }
+          }
+        );
+      })
 
     responses
       .then((manifests) => {

--- a/services/build/canopy.js
+++ b/services/build/canopy.js
@@ -49,6 +49,7 @@ module.exports.build = (env) => {
           index: index,
           label: item.label,
           slug: slug,
+          thumbnail: item.thumbnail? item.thumbnail : [],
         };
       });
 

--- a/services/iiif/constructors/collection.js
+++ b/services/iiif/constructors/collection.js
@@ -7,7 +7,6 @@ const { getRepresentativeImage } = require("../image");
 async function createCollection(iiifResources, label = "") {
   const items = await getCollectionItems(iiifResources);
   const complete_items = await Promise.all(items.map(async ( resource) => await createItem(resource)))
-  console.log(complete_items)
   return {
     "@context": "https://iiif.io/api/presentation/3/context.json",
     id: `http://localhost/featured`,
@@ -20,7 +19,6 @@ async function createCollection(iiifResources, label = "") {
 async function createItem(resource) {
   const { slug } = MANIFESTS.find((item) => item.id === resource.id);
   const thumbnail =  await getRepresentativeImage(resource, 2000);
-  // console.log(thumbnail);
   return {
     id: resource.id,
     label: resource.label,

--- a/services/iiif/constructors/collection.js
+++ b/services/iiif/constructors/collection.js
@@ -2,25 +2,29 @@ const axios = require("axios");
 const { getPresentation3 } = require("../context");
 const { getHomepageBySlug } = require("../homepage");
 const MANIFESTS = require("@/.canopy/manifests.json");
+const { getRepresentativeImage } = require("../image");
 
 async function createCollection(iiifResources, label = "") {
   const items = await getCollectionItems(iiifResources);
-
+  const complete_items = await Promise.all(items.map(async ( resource) => await createItem(resource)))
+  console.log(complete_items)
   return {
     "@context": "https://iiif.io/api/presentation/3/context.json",
     id: `http://localhost/featured`,
     type: "Collection",
     label: { none: [label] },
-    items: items.map((resource) => createItem(resource)),
+    items: complete_items,
   };
 }
 
-function createItem(resource) {
+async function createItem(resource) {
   const { slug } = MANIFESTS.find((item) => item.id === resource.id);
+  const thumbnail =  await getRepresentativeImage(resource, 2000);
+  // console.log(thumbnail);
   return {
     id: resource.id,
     label: resource.label,
-    thumbnail: resource?.thumbnail ? resource?.thumbnail : [],
+    thumbnail: thumbnail ? thumbnail : [],
     homepage: getHomepageBySlug(slug, resource.label),
   };
 }

--- a/services/iiif/constructors/collection.js
+++ b/services/iiif/constructors/collection.js
@@ -6,7 +6,7 @@ const { getRepresentativeImage } = require("../image");
 
 async function createCollection(iiifResources, label = "") {
   const items = await getCollectionItems(iiifResources);
-  const complete_items = await Promise.all(items.map(async ( resource) => await createItem(resource)))
+  const complete_items = await Promise.all(items.map(async (resource) => await createItem(resource)))
   return {
     "@context": "https://iiif.io/api/presentation/3/context.json",
     id: `http://localhost/featured`,

--- a/services/iiif/image.js
+++ b/services/iiif/image.js
@@ -1,0 +1,37 @@
+const axios = require("axios");
+
+const getService = async (service, preferredWidth=1000) => {
+  if (service.hasOwnProperty('@id')){
+    try {
+      const response = await axios.get(`${service['@id']}/info.json`);
+      const {width, height} = response.data.sizes.reduce((a, b)=> {
+        return Math.abs(b.width - preferredWidth) < Math.abs(a.width - preferredWidth) ? b : a;
+      });
+      return {
+        'id': `${service['@id']}/full/${width},${height}/0/default.jpg`,
+        'width': width,
+        'height': height,
+      }
+    }
+    catch (err) {
+      console.log(err.response.status);
+      return {}
+    }
+  }
+};
+
+exports.getRepresentativeImage = async (resource, preferredSize=1000) => {
+  const firstCanvas = resource.items[0].items[0].items[0];
+  const firstCanvasService = await getService(firstCanvas.body.service[0], preferredSize );
+  if (firstCanvasService !== {}) {
+    return [
+      {
+        "id": firstCanvasService.id,
+        "type": "Image",
+        "format": "image/jpeg",
+        "width": firstCanvasService.width,
+        "height": firstCanvasService.height,
+      }
+    ]
+  }
+};

--- a/services/iiif/image.js
+++ b/services/iiif/image.js
@@ -22,7 +22,7 @@ const getService = async (service, preferredWidth=1000) => {
 
 exports.getRepresentativeImage = async (resource, preferredSize=1000) => {
   const firstCanvas = resource.items[0].items[0].items[0];
-  const firstCanvasService = await getService(firstCanvas.body.service[0], preferredSize );
+  const firstCanvasService = await getService(firstCanvas.body.service[0], preferredSize);
   if (firstCanvasService !== {}) {
     return [
       {
@@ -33,5 +33,8 @@ exports.getRepresentativeImage = async (resource, preferredSize=1000) => {
         "height": firstCanvasService.height,
       }
     ]
+  }
+  else {
+    return firstCanvas.thumbnail ? firstCanvas.thumbnail : []
   }
 };


### PR DESCRIPTION
# What does this do?

1. Adds a service to get a representative image from a canvas based on a requested image size. 
2. Generates heroes from these images rather than the thumbnail.
3. Modifies build to include thumbnails in the manifest build objects so they can be served to bloom sliders.
4. Modifies api views to include thumbnails.


## What type of change is this?

- [ ] 🐛 **Bug fix** (non-breaking change addressing an issue)
- [x] ✨ **New feature or enhancement** (non-breaking change which adds functionality)
- [ ] 🧨 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚧 **Maintenance or refinement of codebase structur**e (ex: dependency updates)
- [ ] 📘 **Documentation update**

## Additional Notes

1. This does not address thumbnails on works page, but I'll take care of that next.  That still attempts to use the `id` of the body on the annotation page of the annotation on the initial canvas.
2. The getService stuff assumes image 2.  Need to add stuff for image 3.  Do we have a good fixture for testing that?
