### PR TITLE
Style refinements on Sliders, Cards, and Search input.

### DIFF
--- a/components/Card/Card.styled.ts
+++ b/components/Card/Card.styled.ts
@@ -24,6 +24,8 @@ const Placeholder = styled("div", {
   backgroundColor: "$slate6",
   width: "100%",
   height: "100%",
+  overflow: "hidden",
+  borderRadius: "3px",
 });
 
 const Wrapper = styled("div", {

--- a/components/Search/Search.styled.ts
+++ b/components/Search/Search.styled.ts
@@ -9,7 +9,6 @@ const SearchForm = styled("form", {
   margin: "0 $gr4",
   flexGrow: "1",
   flexShrink: "1",
-  maxWidth: "$gr10",
   width: "100%",
   justifyContent: "space-between",
   opacity: "1",

--- a/components/Viewer/Slider.styled.ts
+++ b/components/Viewer/Slider.styled.ts
@@ -11,6 +11,7 @@ const SliderStyled = styled("div", {
   [`& .bloom-header-summary`]: {
     display: "block",
     fontSize: "$gr3 !important",
+    color: "$slate11 ",
   },
 
   ".swiper-slide": {
@@ -34,11 +35,21 @@ const SliderStyled = styled("div", {
     margin: "$gr1 0",
 
     "> span": {
+      textOverflow: "ellipsis",
+      display: "-webkit-box",
+      WebkitBoxOrient: "vertical",
+      WebkitLineClamp: "3",
+      overflow: "hidden",
+      whiteSpace: "normal",
       fontWeight: "500",
       fontSize: "$gr4",
       fontFamily: "$bookTight",
       textDecoration: "none !important",
     },
+  },
+
+  [`& a figcaption, & a:visited figcaption`]: {
+    color: "$slate12",
   },
 
   [`& a:hover figcaption, & a:focus figcaption`]: {


### PR DESCRIPTION
# What does this do?

This addresses  a few minor styling issues:

- Bloom now works better in Dark mode, adds a row/line limit of 3 to to item labels and uses an ellipsis for text overflow
- Search bar grows across the top no longer being confined by a max width
- Cards have an overflow hidden now to help with display in situations where the computed Canvas and Annotation body aspect ratio does not actually match the resource.

## What type of change is this?

- [x] 🐛 **Bug fix** (non-breaking change addressing an issue)
- [ ] ✨ **New feature or enhancement** (non-breaking change which adds functionality)
- [ ] 🧨 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚧 **Maintenance or refinement of codebase structur**e (ex: dependency updates)
- [ ] 📘 **Documentation update**
