### PR TITLE
Add overflow to facet modal body.

### DIFF
--- a/components/Facets/Modal.styled.ts
+++ b/components/Facets/Modal.styled.ts
@@ -18,6 +18,8 @@ const FacetsModalContent = styled(Dialog.Content, {
   borderTop: "1px solid $slateA1",
   borderBottom: "1px solid $slateA4",
   transform: "translateX(-50%)",
+  overflow: "clip",
+  display: "flex",
 
   "@lg": {
     width: `calc(100% - $gr4 * 2)`,
@@ -36,18 +38,19 @@ const FacetsModalContentInner = styled("div", {
   display: "flex",
   flexDirection: "column",
   flexWrap: "nowrap",
+  width: "100%",
+  overflow: "scroll",
 });
 
 const FacetsModalContentHeader = styled("header", {
   display: "flex",
+  flexGrow: "0",
   justifyContent: "space-between",
   padding: "$gr3 $gr4",
   color: "$slate9",
   fontSize: "$gr3",
   fontFamily: "$bookTight",
   fontWeight: "300",
-  flexGrow: "0",
-  flexShrink: "0",
   alignItems: "center",
 
   "@sm": {
@@ -57,10 +60,9 @@ const FacetsModalContentHeader = styled("header", {
 
 const FacetsModalContentFooter = styled("footer", {
   display: "flex",
+  flexGrow: "0",
   justifyContent: "space-between",
   padding: "$gr3 $gr4",
-  flexGrow: "0",
-  flexShrink: "0",
 
   "@sm": {
     padding: "$gr2 $gr3",
@@ -68,11 +70,13 @@ const FacetsModalContentFooter = styled("footer", {
 });
 
 const FacetsModalContentBody = styled("div", {
-  padding: "$gr3 $gr4",
-  height: "100%",
+  display: "flex",
+  flexDirection: "column",
   flexGrow: "1",
-  flexShrink: "1",
-  overflow: "scroll",
+  borderTop: "1px solid $slate4",
+  borderBottom: "1px solid $slate4",
+  overflowY: "scroll !important",
+  padding: "$gr3 $gr4",
 
   "@sm": {
     padding: "$gr2 $gr3",


### PR DESCRIPTION
# What does this do?

This work adds a baseline overflow scroll to the the facet modal body, allowing both the modal Header and Footer to be visible at all times, and for body content for facets to scroll within the remaining space. This should enhance usability in all viewports, allowing for quicker toggling to Clear all, View Results and Close buttons of the modal.

Default view
![image](https://user-images.githubusercontent.com/7376450/221220855-f4c41f1b-7c59-4b8f-858c-3bedf98a041b.png)

Overflow of Body (Dimensions expanded)
![image](https://user-images.githubusercontent.com/7376450/221221197-6f6be7d0-e236-475e-811d-5e8b4cca0d8d.png)



## What type of change is this?

- [ ] 🐛 **Bug fix** (non-breaking change addressing an issue)
- [ ] ✨ **New feature or enhancement** (non-breaking change which adds functionality)
- [ ] 🧨 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚧 **Maintenance or refinement of codebase structur**e (ex: dependency updates)
- [ ] 📘 **Documentation update**