### PR TITLE
If bounds empty, use default bounds.

### DIFF
--- a/components/Map/Map.tsx
+++ b/components/Map/Map.tsx
@@ -29,7 +29,7 @@ const Map: React.FC<MapProps> = ({ manifests }) => {
 
   useEffect( () => {
     const manifestBounds = getBounds(manifests);
-    setBounds(manifestBounds.length > 0 ? manifestBounds : defaultBounds);
+    manifestBounds.length > 0 && setBounds(manifestBounds);
   }, [manifests])
 
   useEffect(() => {

--- a/components/Map/Map.tsx
+++ b/components/Map/Map.tsx
@@ -28,7 +28,8 @@ const Map: React.FC<MapProps> = ({ manifests }) => {
   const [bounds, setBounds] = useState<Leaflet.LatLngBoundsExpression>(defaultBounds);
 
   useEffect( () => {
-    setBounds(getBounds(manifests));
+    const manifestBounds = getBounds(manifests);
+    setBounds(manifestBounds.length > 0 ? manifestBounds : defaultBounds);
   }, [manifests])
 
   useEffect(() => {


### PR DESCRIPTION
# What does this do?

This addresses a bug where if you use the map route without manifests with matching navPlace elements an empty array would be passed to `fitbounds` resulting in an error when state updates.

This ensures `defaultbounds` are used in that case.

## What type of change is this?

- [x] 🐛 **Bug fix** (non-breaking change addressing an issue)
- [ ] ✨ **New feature or enhancement** (non-breaking change which adds functionality)
- [ ] 🧨 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚧 **Maintenance or refinement of codebase structur**e (ex: dependency updates)
- [ ] 📘 **Documentation update**

## Additional Notes

There may be a better way to do this.
