### PR TITLE
Prune packages, update outdated.

### DIFF
--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -30,7 +30,6 @@ const Hero: React.FC<HeroProps> = ({ collection }) => {
         loop={true}
         modules={[Autoplay, EffectFade, Keyboard, Navigation]}
         navigation={collection?.items?.length > 1}
-        preloadImages={false}
         slidesPerView={1}
         speed={200}
       >

--- a/components/Viewer/Viewer.tsx
+++ b/components/Viewer/Viewer.tsx
@@ -30,6 +30,11 @@ const customTheme = {
 const options = {
   canvasBackgroundColor: `$slate6`,
   canvasHeight: `600px`,
+  openSeadragon: {
+    gestureSettingsMouse: {
+      scrollToZoom: false,
+    },
+  },
   renderAbout: false,
   showTitle: false,
   showIIIFBadge: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,25 +8,23 @@
       "dependencies": {
         "@iiif/parser": "^1.1.2",
         "@iiif/vault": "^0.9.22",
-        "@iiif/vault-helpers": "^0.9.11",
+        "@iiif/vault-helpers": "^0.10.0",
         "@mdx-js/loader": "^2.3.0",
         "@next/mdx": "^13.2.3",
         "@radix-ui/colors": "^0.1.8",
-        "@radix-ui/react-accordion": "^1.1.0",
+        "@radix-ui/react-accordion": "^1.1.1",
         "@radix-ui/react-checkbox": "^1.0.1",
         "@radix-ui/react-dialog": "^1.0.2",
         "@radix-ui/react-icons": "^1.1.1",
-        "@radix-ui/react-scroll-area": "^1.0.2",
-        "@radix-ui/react-select": "^1.1.2",
         "@samvera/bloom-iiif": "^0.5.0",
-        "@samvera/clover-iiif": "^1.13.2",
+        "@samvera/clover-iiif": "^1.14.1",
         "@samvera/nectar-iiif": "^0.0.20",
         "@stitches/react": "^1.2.8",
         "axios": "^0.24.0",
         "clsx": "^1.1.1",
         "copy-to-clipboard": "^3.3.3",
         "flexsearch": "^0.7.31",
-        "framer-motion": "^8.5.4",
+        "framer-motion": "^10.9.4",
         "leaflet": "^1.9.3",
         "lodash": "^4.17.21",
         "next": "^13.0.0",
@@ -39,7 +37,7 @@
         "react-leaflet": "^4.2.0",
         "react-masonry-css": "^1.0.16",
         "slugify": "^1.6.3",
-        "swiper": "^8.4.4"
+        "swiper": "^9.1.1"
       },
       "devDependencies": {
         "@iiif/presentation-3": "^1.1.3",
@@ -54,12 +52,13 @@
         "eslint-config-next": "^13.1.1",
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-testing-library": "^5.2.1",
-        "typescript": "^4.9.3"
+        "typescript": "^5.0.2"
       }
     },
     "node_modules/@atlas-viewer/iiif-image-api": {
-      "version": "2.1.0",
-      "license": "MIT",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@atlas-viewer/iiif-image-api/-/iiif-image-api-2.1.1.tgz",
+      "integrity": "sha512-g7gleRz0Guxwj/JqtppiqloabUTCew61GBzon+ZZ7mXpnMQ+zMupLaI1jHfGxM1Xy9a1+zMwPuUTXqTFkEyueA==",
       "peer": true,
       "dependencies": {
         "@iiif/presentation-3": "*",
@@ -67,8 +66,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.20.13",
-      "license": "MIT",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -78,7 +78,8 @@
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "0.8.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
       "optional": true,
       "dependencies": {
         "@emotion/memoize": "0.7.4"
@@ -86,18 +87,43 @@
     },
     "node_modules/@emotion/memoize": {
       "version": "0.7.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
       "optional": true
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
+      "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-      "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
+      "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.4.0",
+        "espree": "^9.5.1",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -112,20 +138,32 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/js": {
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.37.0.tgz",
+      "integrity": "sha512-x5vzdtOOGgFVDCUs81QRB2+liax8rFg3+7hqM+QhBG0/G3F1ZsoYl97UrqgHgQ9KKT7G6c4V+aTUCgu/n22v1A==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "0.7.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.7.3.tgz",
+      "integrity": "sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg=="
     },
     "node_modules/@floating-ui/dom": {
       "version": "0.5.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.5.4.tgz",
+      "integrity": "sha512-419BMceRLq0RrmTSDxn8hf9R3VCJv2K9PUfugh5JyEFmdjzDo+e8U5EdR8nzKq8Yj1htzLm3b6eQEEam3/rrtg==",
       "dependencies": {
         "@floating-ui/core": "^0.7.3"
       }
     },
     "node_modules/@floating-ui/react-dom": {
       "version": "0.7.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-0.7.2.tgz",
+      "integrity": "sha512-1T0sJcpHgX/u4I1OzIEhlcrvkUN8ln39nz7fMoE/2HDHrPiMFoOGR7++GYyfUmIQHkkrTinaeQsO3XWubjSvGg==",
       "dependencies": {
         "@floating-ui/dom": "^0.5.3",
         "use-isomorphic-layout-effect": "^1.1.1"
@@ -180,7 +218,8 @@
     },
     "node_modules/@iiif/presentation-2": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@iiif/presentation-2/-/presentation-2-1.0.4.tgz",
+      "integrity": "sha512-hJakpq62VBajesLJrYPtFm6hcn6c/HkKP7CmKZ5atuzu40m0nifWYsqigR1l9sZGvhhHb/DRshPmiW/0GNrJoA==",
       "peerDependencies": {
         "@iiif/presentation-3": "*"
       }
@@ -209,9 +248,9 @@
       }
     },
     "node_modules/@iiif/vault-helpers": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.9.11.tgz",
-      "integrity": "sha512-4XuFPvu233mMzfU/mMpAqFY5aCTzwhJ0u7MzPcpN8nSfMwbV5Dyvv0PppjcocvbWMUUXScqerRoB1MAfSFas6w==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.10.0.tgz",
+      "integrity": "sha512-gnjTPcZJMIDjwU5K8HYNU8Iix49Awmsr7IhIyxA5ZCqugnLjHvJUOmOvT7q1NRd6ia4+09wxx+EMH0D9mt4cxQ==",
       "dependencies": {
         "@iiif/presentation-2": "1.x",
         "@iiif/presentation-3": "1.x"
@@ -223,7 +262,7 @@
         "svg-arc-to-cubic-bezier": "^3.2.0"
       },
       "peerDependencies": {
-        "@atlas-viewer/iiif-image-api": "2.x",
+        "@atlas-viewer/iiif-image-api": "^2.1.1",
         "@iiif/vault": "0.9.x"
       }
     },
@@ -329,95 +368,24 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/@motionone/animation": {
-      "version": "10.15.1",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/easing": "^10.15.1",
-        "@motionone/types": "^10.15.1",
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/dom": {
-      "version": "10.15.5",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/animation": "^10.15.1",
-        "@motionone/generators": "^10.15.1",
-        "@motionone/types": "^10.15.1",
-        "@motionone/utils": "^10.15.1",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/easing": {
-      "version": "10.15.1",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/generators": {
-      "version": "10.15.1",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/types": "^10.15.1",
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/types": {
-      "version": "10.15.1",
-      "license": "MIT"
-    },
-    "node_modules/@motionone/utils": {
-      "version": "10.15.1",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/types": "^10.15.1",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
-      }
-    },
     "node_modules/@next/env": {
-      "version": "13.1.5",
-      "license": "MIT"
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.2.4.tgz",
+      "integrity": "sha512-+Mq3TtpkeeKFZanPturjcXt+KHfKYnLlX6jMLyCrmpq6OOs4i1GqBOAauSkii9QeKCMTYzGppar21JU57b/GEA=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.1.6.tgz",
-      "integrity": "sha512-o7cauUYsXjzSJkay8wKjpKJf2uLzlggCsGUkPu3lP09Pv97jYlekTC20KJrjQKmSv5DXV0R/uks2ZXhqjNkqAw==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.2.4.tgz",
+      "integrity": "sha512-ck1lI+7r1mMJpqLNa3LJ5pxCfOB1lfJncKmRJeJxcJqcngaFwylreLP7da6Rrjr6u2gVRTfmnkSkjc80IiQCwQ==",
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
       }
     },
-    "node_modules/@next/eslint-plugin-next/node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@next/mdx": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-13.2.3.tgz",
-      "integrity": "sha512-4xo0wF6FMrtQI7587Z6pbXd6crtGJI3axZ2kxbxCNC0osjlLUSeCNg2lahi8JTEpyc0+KH6B0e0bhsymTMkw7Q==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-13.2.4.tgz",
+      "integrity": "sha512-inl7u+OEa4Ok3uL052oa8EDw1bUkMGLVKzFfVBIgG19s29gxQvcWYzxa5t438J31ljApjh6Y5k4AD6yLaCAlQw==",
       "dependencies": {
         "source-map": "^0.7.0"
       },
@@ -435,9 +403,9 @@
       }
     },
     "node_modules/@next/swc-android-arm-eabi": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.1.5.tgz",
-      "integrity": "sha512-QAEf3YM9U0qWVQTxgF3Tsh4OeCN1i9Smsf6cVlwZsPzoLyj2nQ879joCoN+ONqDknkBgG6OG/ajefywL3jw9Cg==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz",
+      "integrity": "sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==",
       "cpu": [
         "arm"
       ],
@@ -450,9 +418,9 @@
       }
     },
     "node_modules/@next/swc-android-arm64": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.1.5.tgz",
-      "integrity": "sha512-ZmtGPTghRuT5YKL0nNcC2bBVSiG1O0is16eIZ2rWSP/hRW64ZCcAew6pxw2rihntNp22UfequjSTHd91WE/tyQ==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.4.tgz",
+      "integrity": "sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==",
       "cpu": [
         "arm64"
       ],
@@ -465,9 +433,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.1.5.tgz",
-      "integrity": "sha512-aeFXK+M/zmG/CNdMJ0tGNs0MWcLueUe7vZ2V6fa+2yz/ZgYJLI7fEfFvVh1p1yBMzupSbZDowvMuCSFTaeg3MA==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.4.tgz",
+      "integrity": "sha512-S6vBl+OrInP47TM3LlYx65betocKUUlTZDDKzTiRDbsRESeyIkBtZ6Qi5uT2zQs4imqllJznVjFd1bXLx3Aa6A==",
       "cpu": [
         "arm64"
       ],
@@ -480,9 +448,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.1.5.tgz",
-      "integrity": "sha512-6mPX0GNRg8NzjV70at8I8pD9YBnPHDpxJCoMuIqysdTjtQhd09Xk6GUhquNhp1kEJzzVk7OW5l2ch4XIJjtY3A==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.4.tgz",
+      "integrity": "sha512-a6LBuoYGcFOPGd4o8TPo7wmv5FnMr+Prz+vYHopEDuhDoMSHOnC+v+Ab4D7F0NMZkvQjEJQdJS3rqgFhlZmKlw==",
       "cpu": [
         "x64"
       ],
@@ -495,9 +463,9 @@
       }
     },
     "node_modules/@next/swc-freebsd-x64": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.1.5.tgz",
-      "integrity": "sha512-nR4a/SNblG0w8hhYRflTZjk4yD99ld18w/FCftw99ziw8sgciBlOXRICJIiRIaMRU8UH7QLSgBOQVnfNcVNKMA==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.4.tgz",
+      "integrity": "sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==",
       "cpu": [
         "x64"
       ],
@@ -510,9 +478,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.1.5.tgz",
-      "integrity": "sha512-EzkltCVKg3gUzamoeKPhGeSgXTTLAhSzc7v/+g1Y+HQa7JKMrlzdRkrJf+H4LJXcz7lnxgNKHGRyZBSXnmJKJw==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.4.tgz",
+      "integrity": "sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==",
       "cpu": [
         "arm"
       ],
@@ -525,9 +493,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.1.5.tgz",
-      "integrity": "sha512-E7HMkdoxStmTUJU4KzBUU4vZ5DHT4Gd327tC3KFZS5lda0NRerJAOCfsRg+fBj22FvCb1UWsX6XI+weL6xhyeQ==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.4.tgz",
+      "integrity": "sha512-xzYZdAeq883MwXgcwc72hqo/F/dwUxCukpDOkx/j1HTq/J0wJthMGjinN9wH5bPR98Mfeh1MZJ91WWPnZOedOg==",
       "cpu": [
         "arm64"
       ],
@@ -540,9 +508,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.1.5.tgz",
-      "integrity": "sha512-qlO0Fd3GQwJS6YpbF9NyL5NGHVZ43dKtZDC/jP4vdeMIYDtSu13HcY/nmA1NdW+RpMwDxSCpx4WKsCCEZGIX8Q==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.4.tgz",
+      "integrity": "sha512-8rXr3WfmqSiYkb71qzuDP6I6R2T2tpkmf83elDN8z783N9nvTJf2E7eLx86wu2OJCi4T05nuxCsh4IOU3LQ5xw==",
       "cpu": [
         "arm64"
       ],
@@ -555,9 +523,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.1.5.tgz",
-      "integrity": "sha512-GftSBFAay2nocGl+KNqFsj6EVSvomaM/bp86hzezbKsTwQmu76PjOCVcejI1gE+4k7f5zPDgCuorF6F04BV0HQ==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.4.tgz",
+      "integrity": "sha512-Ngxh51zGSlYJ4EfpKG4LI6WfquulNdtmHg1yuOYlaAr33KyPJp4HeN/tivBnAHcZkoNy0hh/SbwDyCnz5PFJQQ==",
       "cpu": [
         "x64"
       ],
@@ -570,9 +538,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.1.5.tgz",
-      "integrity": "sha512-UD+3lxU4yuAjd+uBkCDfBpAcbGAVfEcE8mX/efIxUGIImmzN0QzgTHYEpKFnY3Lxu02dIBcwQRT3Q5mfO4obng==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.4.tgz",
+      "integrity": "sha512-gOvwIYoSxd+j14LOcvJr+ekd9fwYT1RyMAHOp7znA10+l40wkFiMONPLWiZuHxfRk+Dy7YdNdDh3ImumvL6VwA==",
       "cpu": [
         "x64"
       ],
@@ -585,9 +553,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.1.5.tgz",
-      "integrity": "sha512-uzsvkQY+K3EbL+97IUHPWZPwjsCmCkdH/O5Cf9wCnh0k0gaj7ob1mGKqr1vNNak+9U7HloGwuHcXnZpijWSP7w==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.4.tgz",
+      "integrity": "sha512-q3NJzcfClgBm4HvdcnoEncmztxrA5GXqKeiZ/hADvC56pwNALt3ngDC6t6qr1YW9V/EPDxCYeaX4zYxHciW4Dw==",
       "cpu": [
         "arm64"
       ],
@@ -600,9 +568,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.1.5.tgz",
-      "integrity": "sha512-v0NaC1w8mPf620GlJaHBdEm3dm4G4AEQMasDqjzQvo0yCRrvtvzMgCIe8MocBxFHzaF6868NybMqvumxP5YxEg==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.4.tgz",
+      "integrity": "sha512-/eZ5ncmHUYtD2fc6EUmAIZlAJnVT2YmxDsKs1Ourx0ttTtvtma/WKlMV5NoUsyOez0f9ExLyOpeCoz5aj+MPXw==",
       "cpu": [
         "ia32"
       ],
@@ -615,9 +583,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.1.5.tgz",
-      "integrity": "sha512-IZHwvd649ccbWyLCfu92IXEpR250NpmBkaRelPV+WVm4jrd62FKRFCNdqdCXq6TrEg9wN8cK4YG8tm44uEZqLA==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.4.tgz",
+      "integrity": "sha512-0MffFmyv7tBLlji01qc0IaPP/LVExzvj7/R5x1Jph1bTAIj4Vu81yFQWHHQAP6r4ff9Ukj1mBK6MDNVXm7Tcvw==",
       "cpu": [
         "x64"
       ],
@@ -665,7 +633,9 @@
       }
     },
     "node_modules/@nulib/design-system": {
-      "version": "1.6.1",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@nulib/design-system/-/design-system-1.6.2.tgz",
+      "integrity": "sha512-tY3lxsfvh9fcNiEa/+o3C9gatRwA38UBMsfWIG2g2NeD4IzOnUmKgNr1FE1O7xxsHMAtIJuQ/A2dtMbWAJwNbw==",
       "dependencies": {
         "@radix-ui/react-popover": "^0.1.7-rc.43",
         "@stitches/react": "^1.2.7",
@@ -702,32 +672,34 @@
     },
     "node_modules/@radix-ui/number": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.0.tgz",
+      "integrity": "sha512-Ofwh/1HX69ZfJRiRBMTy7rgjAzHmwe4kW9C9Y99HTRUcYLUuVT0KESFj15rPjRgKJs20GPq8Bm5aEDJ8DuA3vA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
+      "integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "node_modules/@radix-ui/react-accordion": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.1.0.tgz",
-      "integrity": "sha512-CNN9ZBgCK4i4SX7gFk5s8095j55DUWi85vwRNfkfBLs0QdAG5Tb4ku6sBeugCAiLvsmxw481GyNl+C3stoJVBQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.1.1.tgz",
+      "integrity": "sha512-TQtyyRubYe8DD6DYCovNLTjd2D+TFrNCpr99T5M3cYUbR7BsRxWsxfInjbQ1nHsdy2uPTcnJS5npyXPVfP0piw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-collapsible": "1.0.1",
-        "@radix-ui/react-collection": "1.0.1",
+        "@radix-ui/react-collapsible": "1.0.2",
+        "@radix-ui/react-collection": "1.0.2",
         "@radix-ui/react-compose-refs": "1.0.0",
         "@radix-ui/react-context": "1.0.0",
         "@radix-ui/react-direction": "1.0.0",
         "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-use-controllable-state": "1.0.0"
       },
       "peerDependencies": {
@@ -736,23 +708,61 @@
       }
     },
     "node_modules/@radix-ui/react-arrow": {
-      "version": "1.0.1",
-      "license": "MIT",
+      "version": "0.1.5-rc.47",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-0.1.5-rc.47.tgz",
+      "integrity": "sha512-qx8Ky3FvWHrd6zHTUwvBk83tAbbzqPrXfFor9O31aE91nZIFyMlPo56OkpiRc/rI+4GxbimB/vxVq8UFz2liCg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-primitive": "1.0.1"
+        "@radix-ui/react-primitive": "0.1.5-rc.47"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
       }
     },
-    "node_modules/@radix-ui/react-aspect-ratio": {
-      "version": "1.0.1",
-      "license": "MIT",
+    "node_modules/@radix-ui/react-arrow/node_modules/@radix-ui/react-compose-refs": {
+      "version": "0.1.1-rc.47",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.1-rc.47.tgz",
+      "integrity": "sha512-FJRPt4lAfYEFVc5XfIa1ICprJNGjldbRN6v3NsQVZjNcStQcgFaNvvKzvaUyJS7SwNip0F5Inm7wX7aXOEjxiQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-arrow/node_modules/@radix-ui/react-primitive": {
+      "version": "0.1.5-rc.47",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.5-rc.47.tgz",
+      "integrity": "sha512-eLpWe5H3YoLUjmAERxRQSBjWwu1yhhgljUcxdZMisGBEZNDrRF4Kg1oQvOGJTvQNQ/gUqD784MkbOP6woFcqzg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-primitive": "1.0.1"
+        "@radix-ui/react-slot": "0.1.3-rc.47"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-arrow/node_modules/@radix-ui/react-slot": {
+      "version": "0.1.3-rc.47",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.3-rc.47.tgz",
+      "integrity": "sha512-nurUm75+/nb38nKpHjMqc4GNTDTbDu6KYDdZVJOm+sChaUDVFSdYTHC4A1c9R7k7vtrytFV/obTCc8pqEkU4Gg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "0.1.1-rc.47"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-aspect-ratio": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.0.2.tgz",
+      "integrity": "sha512-YCujQYnwcVcakbdhE8eTjhh4QR8CsngEcRlSzIPWw1vp3KPC9orETo8CxuVM65j5HAp0oFoOlIy6v7SuF+9P+Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.2"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0",
@@ -760,16 +770,16 @@
       }
     },
     "node_modules/@radix-ui/react-checkbox": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.0.1.tgz",
-      "integrity": "sha512-TisH0B8hWmYP3ONRduYCyN04rR9yLPIw/Rwyn1RoC1suSoGCa8Wn+YPdSSSarSszeIbcg3p2lBkDp2XXit4sZw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.0.3.tgz",
+      "integrity": "sha512-55B8/vKzTuzxllH5sGJO4zaBf9gYpJuJRRzaOKm+0oAefRnMvbf+Kgww7IOANVN0w3z7agFJgtnXaZl8Uj95AA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
         "@radix-ui/react-compose-refs": "1.0.0",
         "@radix-ui/react-context": "1.0.0",
         "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-use-controllable-state": "1.0.0",
         "@radix-ui/react-use-previous": "1.0.0",
         "@radix-ui/react-use-size": "1.0.0"
@@ -780,8 +790,9 @@
       }
     },
     "node_modules/@radix-ui/react-collapsible": {
-      "version": "1.0.1",
-      "license": "MIT",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.0.2.tgz",
+      "integrity": "sha512-QNiDT6Au8jUU0K1WV+HEd4loH7C5CKQjeXxskwqyiyAkyCmW7qlQM5vSSJCIoQC+OVPyhgafSmGudRP8Qm1/gA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
@@ -789,7 +800,7 @@
         "@radix-ui/react-context": "1.0.0",
         "@radix-ui/react-id": "1.0.0",
         "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-use-controllable-state": "1.0.0",
         "@radix-ui/react-use-layout-effect": "1.0.0"
       },
@@ -799,13 +810,14 @@
       }
     },
     "node_modules/@radix-ui/react-collection": {
-      "version": "1.0.1",
-      "license": "MIT",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.2.tgz",
+      "integrity": "sha512-s8WdQQ6wNXpaxdZ308KSr8fEWGrg4un8i4r/w7fhiS4ElRNjk5rRcl0/C6TANG2LvLOGIxtzo/jAg6Qf73TEBw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "1.0.0",
         "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-slot": "1.0.1"
       },
       "peerDependencies": {
@@ -815,7 +827,8 @@
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -825,7 +838,8 @@
     },
     "node_modules/@radix-ui/react-context": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
+      "integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -834,21 +848,21 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.2.tgz",
-      "integrity": "sha512-EKxxp2WNSmUPkx4trtWNmZ4/vAYEg7JkAfa1HKBUnaubw9eHzf1Orr9B472lJYaYz327RHDrd4R95fsw7VR8DA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.3.tgz",
+      "integrity": "sha512-owNhq36kNPqC2/a+zJRioPg6HHnTn5B/sh/NjTY8r4W9g1L5VJlrzZIVcBr7R9Mg8iLjVmh6MGgMlfoVf/WO/A==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
         "@radix-ui/react-compose-refs": "1.0.0",
         "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-dismissable-layer": "1.0.2",
+        "@radix-ui/react-dismissable-layer": "1.0.3",
         "@radix-ui/react-focus-guards": "1.0.0",
-        "@radix-ui/react-focus-scope": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.2",
         "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-portal": "1.0.1",
+        "@radix-ui/react-portal": "1.0.2",
         "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-slot": "1.0.1",
         "@radix-ui/react-use-controllable-state": "1.0.0",
         "aria-hidden": "^1.1.1",
@@ -861,7 +875,8 @@
     },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
+      "integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -870,13 +885,14 @@
       }
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.0.2",
-      "license": "MIT",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.3.tgz",
+      "integrity": "sha512-nXZOvFjOuHS1ovumntGV7NNoLaEp9JEvTht3MBjP44NSW5hUKj/8OnfN3+8WmB+CEhN44XaGhpHoSsUIEl5P7Q==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
         "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-use-callback-ref": "1.0.0",
         "@radix-ui/react-use-escape-keydown": "1.0.2"
       },
@@ -887,7 +903,8 @@
     },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.0.tgz",
+      "integrity": "sha512-UagjDk4ijOAnGu4WMUPj9ahi7/zJJqNZ9ZAiGPp7waUWJO0O1aWXi/udPphI0IUjvrhBsZJGSN66dR2dsueLWQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -896,12 +913,13 @@
       }
     },
     "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.0.1",
-      "license": "MIT",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.2.tgz",
+      "integrity": "sha512-spwXlNTfeIprt+kaEWE/qYuYT3ZAqJiAGjN/JgdvgVDTu8yc+HuX+WOWXrKliKnLnwck0F6JDkqIERncnih+4A==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-use-callback-ref": "1.0.0"
       },
       "peerDependencies": {
@@ -910,15 +928,17 @@
       }
     },
     "node_modules/@radix-ui/react-icons": {
-      "version": "1.1.1",
-      "license": "MIT",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.0.tgz",
+      "integrity": "sha512-jQxj/0LKgp+j9BiTXz3O3sgs26RNet2iLWmsPyRz2SIcR4q/4SbazXfnYwbAr+vLYKSfc7qxzyGQA1HLlYiuNw==",
       "peerDependencies": {
         "react": "^16.x || ^17.x || ^18.x"
       }
     },
     "node_modules/@radix-ui/react-id": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
+      "integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-layout-effect": "1.0.0"
@@ -929,7 +949,8 @@
     },
     "node_modules/@radix-ui/react-popover": {
       "version": "0.1.7-rc.47",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-0.1.7-rc.47.tgz",
+      "integrity": "sha512-gzb5laGG4mHTcBFs8VK6ybE7F3uzr/Q+7QJjjGvLL7FI/eV0t9bkWKSJgrvDEXKfjLnSFjZZ80lYcEuuGf6xXw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "0.1.1-rc.7",
@@ -955,26 +976,16 @@
     },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/primitive": {
       "version": "0.1.1-rc.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-0.1.1-rc.7.tgz",
+      "integrity": "sha512-JA0hJY7t2ZACmziHmtO85b5f1haxt9ptWJN9wdVePehfui3ZS3SqpL4asA6lRvvpiLDOl+0y6i69siHpeoUtgA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       }
     },
-    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-arrow": {
-      "version": "0.1.5-rc.47",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-primitive": "0.1.5-rc.47"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-compose-refs": {
       "version": "0.1.1-rc.47",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.1-rc.47.tgz",
+      "integrity": "sha512-FJRPt4lAfYEFVc5XfIa1ICprJNGjldbRN6v3NsQVZjNcStQcgFaNvvKzvaUyJS7SwNip0F5Inm7wX7aXOEjxiQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -984,7 +995,8 @@
     },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-context": {
       "version": "0.1.2-rc.47",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-0.1.2-rc.47.tgz",
+      "integrity": "sha512-0FphpYHmFDKXnxBGgshj0rxDTkws0OfxJ+9ozYtKLDXZ0XLfTt4iTdtjCz8bq7y/6NTa58xnydooGMvR0sVibw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -994,7 +1006,8 @@
     },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-dismissable-layer": {
       "version": "0.1.6-rc.47",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-0.1.6-rc.47.tgz",
+      "integrity": "sha512-XVU5Mv4Un5AL07ZlAFYU2jn7ZZHeTSAH32WGK+9Ok4RpwPW2QUILCaYSyS+kYaOUOgRXa+TmUNy63adui0jjXw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "0.1.1-rc.7",
@@ -1010,7 +1023,8 @@
     },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-focus-guards": {
       "version": "0.1.1-rc.47",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-0.1.1-rc.47.tgz",
+      "integrity": "sha512-rvLQstRn6nxeCL79VGubLV+r9Z+lhZ1M/n2p2YQyF6ShdU8mJJIw805POqMhqNPv0S/ntf9oX3YIGrNnWj1vhw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -1020,7 +1034,8 @@
     },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-focus-scope": {
       "version": "0.1.5-rc.47",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-0.1.5-rc.47.tgz",
+      "integrity": "sha512-pbNMSJ125C2df+A834vM4pg8iUNieiEbQVre/Uq/Ipke1VHkyItPbZ2/skIDTuJOSA4MecEeI/70ZbW6uNaS/g==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "0.1.1-rc.47",
@@ -1034,7 +1049,8 @@
     },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-id": {
       "version": "0.1.6-rc.47",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.6-rc.47.tgz",
+      "integrity": "sha512-6JS+DXKyLgLPeLPnEXdN8vBjFME2P290/xvsQ5NDZq0WWCCzjaCgB1jq+ZnazVQPdtq7PBhldDN3j33QYMUOlg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-layout-effect": "0.1.1-rc.47"
@@ -1043,29 +1059,10 @@
         "react": "^16.8 || ^17.0 || ^18.0"
       }
     },
-    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-popper": {
-      "version": "0.1.5-rc.47",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@floating-ui/react-dom": "0.7.2",
-        "@radix-ui/react-arrow": "0.1.5-rc.47",
-        "@radix-ui/react-compose-refs": "0.1.1-rc.47",
-        "@radix-ui/react-context": "0.1.2-rc.47",
-        "@radix-ui/react-primitive": "0.1.5-rc.47",
-        "@radix-ui/react-use-layout-effect": "0.1.1-rc.47",
-        "@radix-ui/react-use-rect": "0.1.2-rc.47",
-        "@radix-ui/react-use-size": "0.1.2-rc.47",
-        "@radix-ui/rect": "0.1.2-rc.7"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-portal": {
       "version": "0.1.5-rc.47",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-0.1.5-rc.47.tgz",
+      "integrity": "sha512-vhCvW/V6xWsbA3/SQN4zzVFQtZpbZTDrq0p/KM+MhPx/jo46PLmtRLudT5h30AVzwTniLpjeMziy2Oy8aozFcQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "0.1.5-rc.47"
@@ -1077,7 +1074,8 @@
     },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-presence": {
       "version": "0.1.3-rc.47",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-0.1.3-rc.47.tgz",
+      "integrity": "sha512-7Ey537IfQvXVBq66FyUEVfSPG5/4k46by/3VTmKgDYVD9MXG1TSyML7sJxaphydDAYTqCcPTFcWNTwbMDGiMvw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "0.1.1-rc.47",
@@ -1090,7 +1088,8 @@
     },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-primitive": {
       "version": "0.1.5-rc.47",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.5-rc.47.tgz",
+      "integrity": "sha512-eLpWe5H3YoLUjmAERxRQSBjWwu1yhhgljUcxdZMisGBEZNDrRF4Kg1oQvOGJTvQNQ/gUqD784MkbOP6woFcqzg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-slot": "0.1.3-rc.47"
@@ -1102,7 +1101,8 @@
     },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
       "version": "0.1.3-rc.47",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.3-rc.47.tgz",
+      "integrity": "sha512-nurUm75+/nb38nKpHjMqc4GNTDTbDu6KYDdZVJOm+sChaUDVFSdYTHC4A1c9R7k7vtrytFV/obTCc8pqEkU4Gg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "0.1.1-rc.47"
@@ -1113,7 +1113,8 @@
     },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-callback-ref": {
       "version": "0.1.1-rc.47",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.1-rc.47.tgz",
+      "integrity": "sha512-a/Q1GFXBDzgnRXI1/MV+P8CRXJZtManDS3zqq34avcLJB4adTVR4+mA3jPMEPsyKaqA08wzHtynSC2hgstRXsw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -1123,7 +1124,8 @@
     },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-controllable-state": {
       "version": "0.1.1-rc.47",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.1.1-rc.47.tgz",
+      "integrity": "sha512-3MclvPRcCKFXDBxVAJdrkl7s3GKunav/fPE9plYwXy4Kg0cHT4EVAMfZZSG2MhqnBf5WpovYsX5Rtsrh7LwWRQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-callback-ref": "0.1.1-rc.47"
@@ -1134,7 +1136,8 @@
     },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-escape-keydown": {
       "version": "0.1.1-rc.47",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-0.1.1-rc.47.tgz",
+      "integrity": "sha512-a+/9xr5OgHfJCuGLwu8eoc6Vtee3ts5d9yX23sxUoj9q5utDJnodOslkzYmjheP2FOuI/IgrltjwPDdOZcqYPA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-callback-ref": "0.1.1-rc.47"
@@ -1145,46 +1148,19 @@
     },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-layout-effect": {
       "version": "0.1.1-rc.47",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.1-rc.47.tgz",
+      "integrity": "sha512-ke77SzDqR+7qOXSL6wg95VxMRa3v+J//bnFZXdyA2Pc/J6EtwINoopOzDZvs2cp6yC3qRIWg5NWyGZVKUeQzSw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-rect": {
-      "version": "0.1.2-rc.47",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/rect": "0.1.2-rc.7"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-size": {
-      "version": "0.1.2-rc.47",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-layout-effect": "0.1.1-rc.47"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/rect": {
-      "version": "0.1.2-rc.7",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
       }
     },
     "node_modules/@radix-ui/react-popover/node_modules/react-remove-scroll": {
       "version": "2.5.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.4.tgz",
+      "integrity": "sha512-xGVKJJr0SJGQVirVFAUZ2k1QLyO6m+2fy0l8Qawbp5Jgrv3DeLalrfMNBFSlmz5kriGGzsVBtGVnf4pTKIhhWA==",
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.3",
         "react-style-singleton": "^2.2.1",
@@ -1206,32 +1182,103 @@
       }
     },
     "node_modules/@radix-ui/react-popper": {
-      "version": "1.1.0",
-      "license": "MIT",
+      "version": "0.1.5-rc.47",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-0.1.5-rc.47.tgz",
+      "integrity": "sha512-HQc54eMp/GyPEbTZO5xBTM6CsquYDwtBFJcbw5sbx359jgEIG+OzBpiGtyzGmH7WJkrMnADizJC48LY3XMAlTA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@floating-ui/react-dom": "0.7.2",
-        "@radix-ui/react-arrow": "1.0.1",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
-        "@radix-ui/react-use-callback-ref": "1.0.0",
-        "@radix-ui/react-use-layout-effect": "1.0.0",
-        "@radix-ui/react-use-rect": "1.0.0",
-        "@radix-ui/react-use-size": "1.0.0",
-        "@radix-ui/rect": "1.0.0"
+        "@radix-ui/react-arrow": "0.1.5-rc.47",
+        "@radix-ui/react-compose-refs": "0.1.1-rc.47",
+        "@radix-ui/react-context": "0.1.2-rc.47",
+        "@radix-ui/react-primitive": "0.1.5-rc.47",
+        "@radix-ui/react-use-layout-effect": "0.1.1-rc.47",
+        "@radix-ui/react-use-rect": "0.1.2-rc.47",
+        "@radix-ui/react-use-size": "0.1.2-rc.47",
+        "@radix-ui/rect": "0.1.2-rc.7"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
       }
     },
-    "node_modules/@radix-ui/react-portal": {
-      "version": "1.0.1",
-      "license": "MIT",
+    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-compose-refs": {
+      "version": "0.1.1-rc.47",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.1-rc.47.tgz",
+      "integrity": "sha512-FJRPt4lAfYEFVc5XfIa1ICprJNGjldbRN6v3NsQVZjNcStQcgFaNvvKzvaUyJS7SwNip0F5Inm7wX7aXOEjxiQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-context": {
+      "version": "0.1.2-rc.47",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-0.1.2-rc.47.tgz",
+      "integrity": "sha512-0FphpYHmFDKXnxBGgshj0rxDTkws0OfxJ+9ozYtKLDXZ0XLfTt4iTdtjCz8bq7y/6NTa58xnydooGMvR0sVibw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-primitive": {
+      "version": "0.1.5-rc.47",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.5-rc.47.tgz",
+      "integrity": "sha512-eLpWe5H3YoLUjmAERxRQSBjWwu1yhhgljUcxdZMisGBEZNDrRF4Kg1oQvOGJTvQNQ/gUqD784MkbOP6woFcqzg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-primitive": "1.0.1"
+        "@radix-ui/react-slot": "0.1.3-rc.47"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-slot": {
+      "version": "0.1.3-rc.47",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.3-rc.47.tgz",
+      "integrity": "sha512-nurUm75+/nb38nKpHjMqc4GNTDTbDu6KYDdZVJOm+sChaUDVFSdYTHC4A1c9R7k7vtrytFV/obTCc8pqEkU4Gg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "0.1.1-rc.47"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "0.1.1-rc.47",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.1-rc.47.tgz",
+      "integrity": "sha512-ke77SzDqR+7qOXSL6wg95VxMRa3v+J//bnFZXdyA2Pc/J6EtwINoopOzDZvs2cp6yC3qRIWg5NWyGZVKUeQzSw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-use-size": {
+      "version": "0.1.2-rc.47",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-0.1.2-rc.47.tgz",
+      "integrity": "sha512-b9Czuxdf9mOM7k44l5agGC9XGXCri0DEzn4BUfoyQln/dRjZp67V7FkjT9rrDrRjxt1IL99V1INLtgfS0u8tUA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "0.1.1-rc.47"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.2.tgz",
+      "integrity": "sha512-swu32idoCW7KA2VEiUZGBSu9nB6qwGdV6k6HYhUoOo3M1FFpD+VgLzUqtt3mwL1ssz7r2x8MggpLSQach2Xy/Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.2"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0",
@@ -1240,7 +1287,8 @@
     },
     "node_modules/@radix-ui/react-presence": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
+      "integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "1.0.0",
@@ -1252,8 +1300,9 @@
       }
     },
     "node_modules/@radix-ui/react-primitive": {
-      "version": "1.0.1",
-      "license": "MIT",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.2.tgz",
+      "integrity": "sha512-zY6G5Qq4R8diFPNwtyoLRZBxzu1Z+SXMlfYpChN7Dv8gvmx9X3qhDqiLWvKseKVJMuedFeU/Sa0Sy/Ia+t06Dw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-slot": "1.0.1"
@@ -1264,8 +1313,9 @@
       }
     },
     "node_modules/@radix-ui/react-radio-group": {
-      "version": "1.1.1",
-      "license": "MIT",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.1.2.tgz",
+      "integrity": "sha512-S7K8upMjOkx1fTUzEugbfCYPwI9Yw4m2h2ZfJP+ZWP/Mzc/LE2T6QgiAMaSaC3vZSxU5Kk5Eb377zMklWeaaCQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
@@ -1273,8 +1323,8 @@
         "@radix-ui/react-context": "1.0.0",
         "@radix-ui/react-direction": "1.0.0",
         "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
-        "@radix-ui/react-roving-focus": "1.0.2",
+        "@radix-ui/react-primitive": "1.0.2",
+        "@radix-ui/react-roving-focus": "1.0.3",
         "@radix-ui/react-use-controllable-state": "1.0.0",
         "@radix-ui/react-use-previous": "1.0.0",
         "@radix-ui/react-use-size": "1.0.0"
@@ -1285,17 +1335,18 @@
       }
     },
     "node_modules/@radix-ui/react-roving-focus": {
-      "version": "1.0.2",
-      "license": "MIT",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.3.tgz",
+      "integrity": "sha512-stjCkIoMe6h+1fWtXlA6cRfikdBzCLp3SnVk7c48cv/uy3DTGoXhN76YaOYUJuy3aEDvDIKwKR5KSmvrtPvQPQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-collection": "1.0.1",
+        "@radix-ui/react-collection": "1.0.2",
         "@radix-ui/react-compose-refs": "1.0.0",
         "@radix-ui/react-context": "1.0.0",
         "@radix-ui/react-direction": "1.0.0",
         "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-use-callback-ref": "1.0.0",
         "@radix-ui/react-use-controllable-state": "1.0.0"
       },
@@ -1304,51 +1355,31 @@
         "react-dom": "^16.8 || ^17.0 || ^18.0"
       }
     },
-    "node_modules/@radix-ui/react-scroll-area": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.0.2.tgz",
-      "integrity": "sha512-k8VseTxI26kcKJaX0HPwkvlNBPTs56JRdYzcZ/vzrNUkDlvXBy8sMc7WvCpYzZkHgb+hd72VW9MqkqecGtuNgg==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/number": "1.0.0",
-        "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-direction": "1.0.0",
-        "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
-        "@radix-ui/react-use-callback-ref": "1.0.0",
-        "@radix-ui/react-use-layout-effect": "1.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
     "node_modules/@radix-ui/react-select": {
-      "version": "1.2.0",
-      "license": "MIT",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-1.2.1.tgz",
+      "integrity": "sha512-GULRMITaOHNj79BZvQs3iZO0+f2IgI8g5HDhMi7Bnc13t7IlG86NFtOCfTLme4PNZdEtU+no+oGgcl6IFiphpQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/number": "1.0.0",
         "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-collection": "1.0.1",
+        "@radix-ui/react-collection": "1.0.2",
         "@radix-ui/react-compose-refs": "1.0.0",
         "@radix-ui/react-context": "1.0.0",
         "@radix-ui/react-direction": "1.0.0",
-        "@radix-ui/react-dismissable-layer": "1.0.2",
+        "@radix-ui/react-dismissable-layer": "1.0.3",
         "@radix-ui/react-focus-guards": "1.0.0",
-        "@radix-ui/react-focus-scope": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.2",
         "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-popper": "1.1.0",
-        "@radix-ui/react-portal": "1.0.1",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-popper": "1.1.1",
+        "@radix-ui/react-portal": "1.0.2",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-slot": "1.0.1",
         "@radix-ui/react-use-callback-ref": "1.0.0",
         "@radix-ui/react-use-controllable-state": "1.0.0",
         "@radix-ui/react-use-layout-effect": "1.0.0",
         "@radix-ui/react-use-previous": "1.0.0",
-        "@radix-ui/react-visually-hidden": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.2",
         "aria-hidden": "^1.1.1",
         "react-remove-scroll": "2.5.5"
       },
@@ -1357,9 +1388,65 @@
         "react-dom": "^16.8 || ^17.0 || ^18.0"
       }
     },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-arrow": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.0.2.tgz",
+      "integrity": "sha512-fqYwhhI9IarZ0ll2cUSfKuXHlJK0qE4AfnRrPBbRwEH/4mGQn04/QFGomLi8TXWIdv9WJk//KgGm+aDxVIr1wA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-popper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.1.1.tgz",
+      "integrity": "sha512-keYDcdMPNMjSC8zTsZ8wezUMiWM9Yj14wtF3s0PTIs9srnEPC9Kt2Gny1T3T81mmSeyDjZxsD9N5WCwNNb712w==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@floating-ui/react-dom": "0.7.2",
+        "@radix-ui/react-arrow": "1.0.2",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.2",
+        "@radix-ui/react-use-callback-ref": "1.0.0",
+        "@radix-ui/react-use-layout-effect": "1.0.0",
+        "@radix-ui/react-use-rect": "1.0.0",
+        "@radix-ui/react-use-size": "1.0.0",
+        "@radix-ui/rect": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-use-rect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.0.0.tgz",
+      "integrity": "sha512-TB7pID8NRMEHxb/qQJpvSt3hQU4sqNPM1VCTjTRjEOa7cEop/QMuq8S6fb/5Tsz64kqSvB9WnwsDHtjnrM9qew==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/rect": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/rect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.0.0.tgz",
+      "integrity": "sha512-d0O68AYy/9oeEy1DdC07bz1/ZXX+DqCskRd3i4JzLSTXwefzaepQrKjXC7aNM8lTHjFLDO0pDgaEiQ7jEk+HVg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
+      "integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "1.0.0"
@@ -1369,14 +1456,15 @@
       }
     },
     "node_modules/@radix-ui/react-switch": {
-      "version": "1.0.1",
-      "license": "MIT",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.0.2.tgz",
+      "integrity": "sha512-BcG/LKehxt36NXG0wPnoCitIfSMtU9Xo7BmythYA1PAMLtsMvW7kALfBzmduQoHTWcKr0AVcFyh0gChBUp9TiQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
         "@radix-ui/react-compose-refs": "1.0.0",
         "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-use-controllable-state": "1.0.0",
         "@radix-ui/react-use-previous": "1.0.0",
         "@radix-ui/react-use-size": "1.0.0"
@@ -1387,8 +1475,9 @@
       }
     },
     "node_modules/@radix-ui/react-tabs": {
-      "version": "1.0.2",
-      "license": "MIT",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.3.tgz",
+      "integrity": "sha512-4CkF/Rx1GcrusI/JZ1Rvyx4okGUs6wEenWA0RG/N+CwkRhTy7t54y7BLsWUXrAz/GRbBfHQg/Odfs/RoW0CiRA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
@@ -1396,8 +1485,8 @@
         "@radix-ui/react-direction": "1.0.0",
         "@radix-ui/react-id": "1.0.0",
         "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
-        "@radix-ui/react-roving-focus": "1.0.2",
+        "@radix-ui/react-primitive": "1.0.2",
+        "@radix-ui/react-roving-focus": "1.0.3",
         "@radix-ui/react-use-controllable-state": "1.0.0"
       },
       "peerDependencies": {
@@ -1407,7 +1496,8 @@
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
+      "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -1417,7 +1507,8 @@
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
+      "integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-callback-ref": "1.0.0"
@@ -1428,7 +1519,8 @@
     },
     "node_modules/@radix-ui/react-use-escape-keydown": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.2.tgz",
+      "integrity": "sha512-DXGim3x74WgUv+iMNCF+cAo8xUHHeqvjx8zs7trKf+FkQKPQXLk2sX7Gx1ysH7Q76xCpZuxIJE7HLPxRE+Q+GA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-callback-ref": "1.0.0"
@@ -1439,7 +1531,8 @@
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+      "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -1449,7 +1542,8 @@
     },
     "node_modules/@radix-ui/react-use-previous": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.0.0.tgz",
+      "integrity": "sha512-RG2K8z/K7InnOKpq6YLDmT49HGjNmrK+fr82UCVKT2sW0GYfVnYp4wZWBooT/EYfQ5faA9uIjvsuMMhH61rheg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -1458,11 +1552,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-rect": {
-      "version": "1.0.0",
-      "license": "MIT",
+      "version": "0.1.2-rc.47",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-0.1.2-rc.47.tgz",
+      "integrity": "sha512-u0PRRQQvnl9tld+7qAbWsrfN2rrtjyfXqK5+9BOooMWt9H6+OWDlau20iQzHdswuJfg8zeyO3u00k56r1tVSrw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/rect": "1.0.0"
+        "@radix-ui/rect": "0.1.2-rc.7"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0"
@@ -1470,7 +1565,8 @@
     },
     "node_modules/@radix-ui/react-use-size": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.0.0.tgz",
+      "integrity": "sha512-imZ3aYcoYCKhhgNpkNDh/aTiU05qw9hX+HHI1QDBTyIlcFjgeFlKKySNGMwTp7nYFLQg/j0VA2FmCY4WPDDHMg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-layout-effect": "1.0.0"
@@ -1480,11 +1576,12 @@
       }
     },
     "node_modules/@radix-ui/react-visually-hidden": {
-      "version": "1.0.1",
-      "license": "MIT",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.2.tgz",
+      "integrity": "sha512-qirnJxtYn73HEk1rXL12/mXnu2rwsNHDID10th2JGtdK25T9wX+mxRmGt7iPSahw512GbZOc0syZX1nLQGoEOg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-primitive": "1.0.1"
+        "@radix-ui/react-primitive": "1.0.2"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0",
@@ -1492,15 +1589,17 @@
       }
     },
     "node_modules/@radix-ui/rect": {
-      "version": "1.0.0",
-      "license": "MIT",
+      "version": "0.1.2-rc.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-0.1.2-rc.7.tgz",
+      "integrity": "sha512-cfTp+HLF++BYp4RmwSUNCvjD+c6jahzVwkMUdFN6PLJSA/zLZR0OOXkvQhhNBOg9/XOxOLEJuYE8RJG5o2P1QA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "node_modules/@react-leaflet/core": {
       "version": "2.1.0",
-      "license": "Hippocratic-2.1",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
       "peerDependencies": {
         "leaflet": "^1.9.0",
         "react": "^18.0.0",
@@ -1529,9 +1628,29 @@
         "swiper": "^8.4.5"
       }
     },
+    "node_modules/@samvera/bloom-iiif/node_modules/@iiif/vault-helpers": {
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.9.11.tgz",
+      "integrity": "sha512-4XuFPvu233mMzfU/mMpAqFY5aCTzwhJ0u7MzPcpN8nSfMwbV5Dyvv0PppjcocvbWMUUXScqerRoB1MAfSFas6w==",
+      "dependencies": {
+        "@iiif/presentation-2": "1.x",
+        "@iiif/presentation-3": "1.x"
+      },
+      "optionalDependencies": {
+        "abs-svg-path": "^0.1.0",
+        "parse-svg-path": "^0.1.0",
+        "react-i18next": "^11.18.0",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      },
+      "peerDependencies": {
+        "@atlas-viewer/iiif-image-api": "2.x",
+        "@iiif/vault": "0.9.x"
+      }
+    },
     "node_modules/@samvera/bloom-iiif/node_modules/@samvera/nectar-iiif": {
       "version": "0.0.18",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.18.tgz",
+      "integrity": "sha512-o5gNHdhoG12bNC56lAgT050SKKnDWYTNwaJJGD9qnS48gmVR+FGsTSrLub9boesU0uo6wanMJBsMBSPgt4IlvA==",
       "dependencies": {
         "@stitches/react": "^1.2.7",
         "hls.js": "^1.1.5",
@@ -1540,12 +1659,36 @@
         "sanitize-html": "^2.7.0"
       }
     },
+    "node_modules/@samvera/bloom-iiif/node_modules/swiper": {
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.7.tgz",
+      "integrity": "sha512-VwO/KU3i9IV2Sf+W2NqyzwWob4yX9Qdedq6vBtS0rFqJ6Fa5iLUJwxQkuD4I38w0WDJwmFl8ojkdcRFPHWD+2g==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "hasInstallScript": true,
+      "dependencies": {
+        "dom7": "^4.0.4",
+        "ssr-window": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 4.7.0"
+      }
+    },
     "node_modules/@samvera/clover-iiif": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.13.2.tgz",
-      "integrity": "sha512-KVQBRZfMGw4VsLp8GLPZoNYboY6164G22cdsn/i3byNU6qiPYm9tuUKg9AquQwCxXWSJf2k53l9Roqy9QjRn6A==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.14.1.tgz",
+      "integrity": "sha512-5VcR/UnWn17PJVDmmS0VzNf0POYqfhoW88LZ2WH8CZUhVSihNnqBcUO2qhPPxhGcAKnOGYy2TPTQit7vMSHILg==",
       "dependencies": {
         "@iiif/vault": "^0.9.19",
+        "@iiif/vault-helpers": "^0.9.11",
         "@nulib/design-system": "^1.6.0",
         "@radix-ui/react-collapsible": "^1.0.1",
         "@radix-ui/react-radio-group": "^1.1.0",
@@ -1563,9 +1706,29 @@
         "uuid": "^9.0.0"
       }
     },
+    "node_modules/@samvera/clover-iiif/node_modules/@iiif/vault-helpers": {
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.9.11.tgz",
+      "integrity": "sha512-4XuFPvu233mMzfU/mMpAqFY5aCTzwhJ0u7MzPcpN8nSfMwbV5Dyvv0PppjcocvbWMUUXScqerRoB1MAfSFas6w==",
+      "dependencies": {
+        "@iiif/presentation-2": "1.x",
+        "@iiif/presentation-3": "1.x"
+      },
+      "optionalDependencies": {
+        "abs-svg-path": "^0.1.0",
+        "parse-svg-path": "^0.1.0",
+        "react-i18next": "^11.18.0",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      },
+      "peerDependencies": {
+        "@atlas-viewer/iiif-image-api": "2.x",
+        "@iiif/vault": "0.9.x"
+      }
+    },
     "node_modules/@samvera/clover-iiif/node_modules/@samvera/nectar-iiif": {
       "version": "0.0.18",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.18.tgz",
+      "integrity": "sha512-o5gNHdhoG12bNC56lAgT050SKKnDWYTNwaJJGD9qnS48gmVR+FGsTSrLub9boesU0uo6wanMJBsMBSPgt4IlvA==",
       "dependencies": {
         "@stitches/react": "^1.2.7",
         "hls.js": "^1.1.5",
@@ -1588,14 +1751,16 @@
     },
     "node_modules/@stitches/react": {
       "version": "1.2.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@stitches/react/-/react-1.2.8.tgz",
+      "integrity": "sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==",
       "peerDependencies": {
         "react": ">= 16.3.0"
       }
     },
     "node_modules/@swc/helpers": {
       "version": "0.4.14",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1617,9 +1782,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.1.tgz",
-      "integrity": "sha512-rc9K8ZpVjNcLs8Fp0dkozd5Pt2Apk1glO4Vgz8ix1u6yFByxfqo5Yavpy65o+93TAe24jr7v+eSBtFLvOQtCRQ==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.3.tgz",
+      "integrity": "sha512-fa7GkppZVEByMWGbTtE5MbmXWJTVbrjjaS8K6uQj+XtuuUv1fsuPAxhygfqLmsb/Ufb3CV8deFCpiMfAgi00Sw==",
       "peer": true,
       "dependencies": {
         "@types/estree": "*",
@@ -1651,7 +1816,8 @@
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.10",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
     },
     "node_modules/@types/hast": {
       "version": "2.3.4",
@@ -1673,31 +1839,32 @@
       "dev": true
     },
     "node_modules/@types/leaflet": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.0.tgz",
-      "integrity": "sha512-7LeOSj7EloC5UcyOMo+1kc3S1UT3MjJxwqsMT1d2PTyvQz53w0Y0oSSk9nwZnOZubCmBvpSNGceucxiq+ZPEUw==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.3.tgz",
+      "integrity": "sha512-Caa1lYOgKVqDkDZVWkto2Z5JtVo09spEaUt2S69LiugbBpoqQu92HYFMGUbYezZbnBkyOxMNPXHSgRrRY5UyIA==",
       "dev": true,
       "dependencies": {
         "@types/geojson": "*"
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.191",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.14.192",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.192.tgz",
+      "integrity": "sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A==",
+      "dev": true
     },
     "node_modules/@types/mdast": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
-      "integrity": "sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz",
+      "integrity": "sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==",
       "dependencies": {
         "@types/unist": "*"
       }
     },
     "node_modules/@types/mdx": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.3.tgz",
-      "integrity": "sha512-IgHxcT3RC8LzFLhKwP3gbMPeaK7BM9eBH46OdapPA7yvuIUJ8H6zHZV53J8hGZcTSnt95jANt+rTBNUUc22ACQ=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.4.tgz",
+      "integrity": "sha512-qCYrNdpKwN6YO6FVnx+ulfqifKlE3lQGsNhvDaW9Oxzyob/cRLBJWow8GHBBD4NxQ7BVvtsATgLsX0vZAWmtrg=="
     },
     "node_modules/@types/ms": {
       "version": "0.7.31",
@@ -1705,18 +1872,21 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "18.11.18",
-      "license": "MIT"
+      "version": "18.15.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
-      "devOptional": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "devOptional": true
     },
     "node_modules/@types/react": {
-      "version": "18.0.27",
+      "version": "18.0.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.31.tgz",
+      "integrity": "sha512-EEG67of7DsvRDU6BLLI0p+k1GojDLz9+lZsnCpCRTa/lOokvyPBvp8S5x+A24hME3yyQuIipcP70KJ6H7Qupww==",
       "devOptional": true,
-      "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1724,17 +1894,19 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.0.10",
+      "version": "18.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
+      "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/react": "*"
       }
     },
     "node_modules/@types/scheduler": {
-      "version": "0.16.2",
-      "devOptional": true,
-      "license": "MIT"
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
+      "devOptional": true
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -1748,19 +1920,19 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.52.0.tgz",
-      "integrity": "sha512-lHazYdvYVsBokwCdKOppvYJKaJ4S41CgKBcPvyd0xjZNbvQdhn/pnJlGtQksQ/NhInzdaeaSarlBjDXHuclEbg==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.0.tgz",
+      "integrity": "sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.52.0",
-        "@typescript-eslint/type-utils": "5.52.0",
-        "@typescript-eslint/utils": "5.52.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/type-utils": "5.57.0",
+        "@typescript-eslint/utils": "5.57.0",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
-        "regexpp": "^3.2.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
@@ -1782,14 +1954,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.52.0.tgz",
-      "integrity": "sha512-e2KiLQOZRo4Y0D/b+3y08i3jsekoSkOYStROYmPUnGMEoA0h+k2qOH5H6tcjIc68WDvGwH+PaOrP1XRzLJ6QlA==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.0.tgz",
+      "integrity": "sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.52.0",
-        "@typescript-eslint/types": "5.52.0",
-        "@typescript-eslint/typescript-estree": "5.52.0",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1809,13 +1981,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.52.0.tgz",
-      "integrity": "sha512-AR7sxxfBKiNV0FWBSARxM8DmNxrwgnYMPwmpkC1Pl1n+eT8/I2NAUPuwDy/FmDcC6F8pBfmOcaxcxRHspgOBMw==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.0.tgz",
+      "integrity": "sha512-NANBNOQvllPlizl9LatX8+MHi7bx7WGIWYjPHDmQe5Si/0YEYfxSljJpoTyTWFTgRy3X8gLYSE4xQ2U+aCozSw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.52.0",
-        "@typescript-eslint/visitor-keys": "5.52.0"
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/visitor-keys": "5.57.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1826,13 +1998,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.52.0.tgz",
-      "integrity": "sha512-tEKuUHfDOv852QGlpPtB3lHOoig5pyFQN/cUiZtpw99D93nEBjexRLre5sQZlkMoHry/lZr8qDAt2oAHLKA6Jw==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.57.0.tgz",
+      "integrity": "sha512-kxXoq9zOTbvqzLbdNKy1yFrxLC6GDJFE2Yuo3KqSwTmDOFjUGeWSakgoXT864WcK5/NAJkkONCiKb1ddsqhLXQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.52.0",
-        "@typescript-eslint/utils": "5.52.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
+        "@typescript-eslint/utils": "5.57.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -1853,9 +2025,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.52.0.tgz",
-      "integrity": "sha512-oV7XU4CHYfBhk78fS7tkum+/Dpgsfi91IIDy7fjCyq2k6KB63M6gMC0YIvy+iABzmXThCRI6xpCEyVObBdWSDQ==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.0.tgz",
+      "integrity": "sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1866,13 +2038,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.52.0.tgz",
-      "integrity": "sha512-WeWnjanyEwt6+fVrSR0MYgEpUAuROxuAH516WPjUblIrClzYJj0kBbjdnbQXLpgAN8qbEuGywiQsXUVDiAoEuQ==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.0.tgz",
+      "integrity": "sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.52.0",
-        "@typescript-eslint/visitor-keys": "5.52.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/visitor-keys": "5.57.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1893,18 +2065,18 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.52.0.tgz",
-      "integrity": "sha512-As3lChhrbwWQLNk2HC8Ree96hldKIqk98EYvypd3It8Q1f8d5zWyIoaZEp2va5667M4ZyE7X8UUR+azXrFl+NA==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.57.0.tgz",
+      "integrity": "sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==",
       "dev": true,
       "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.52.0",
-        "@typescript-eslint/types": "5.52.0",
-        "@typescript-eslint/typescript-estree": "5.52.0",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       },
       "engines": {
@@ -1919,12 +2091,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.52.0.tgz",
-      "integrity": "sha512-qMwpw6SU5VHCPr99y274xhbm+PRViK/NATY6qzt+Et7+mThGuFSl/ompj2/hrBlRP/kq+BFdgagnOSgw9TB0eA==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.0.tgz",
+      "integrity": "sha512-ery2g3k0hv5BLiKpPuwYt9KBkAp2ugT6VvyShXdLOkax895EC55sP0Tx5L0fZaQueiK3fBLvHVvEl3jFS5ia+g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.52.0",
+        "@typescript-eslint/types": "5.57.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -2095,7 +2267,8 @@
     },
     "node_modules/abs-svg-path": {
       "version": "0.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
       "optional": true
     },
     "node_modules/acorn": {
@@ -2181,22 +2354,14 @@
       "dev": true
     },
     "node_modules/aria-hidden": {
-      "version": "1.2.2",
-      "license": "MIT",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
+      "integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
       "dependencies": {
         "tslib": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.9.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/aria-query": {
@@ -2206,6 +2371,19 @@
       "dev": true,
       "dependencies": {
         "deep-equal": "^2.0.5"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-includes": {
@@ -2322,7 +2500,8 @@
     },
     "node_modules/axios": {
       "version": "0.24.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "dependencies": {
         "follow-redirects": "^1.14.4"
       }
@@ -2430,7 +2609,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001449",
+      "version": "1.0.30001472",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001472.tgz",
+      "integrity": "sha512-xWC/0+hHHQgj3/vrKYY0AAzeIUgr7L9wlELIcAvZdDUHlhL/kNxMdnQLOSOQfP8R51ZzPhmHdyMkI0MMpmxCfg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2439,9 +2620,12 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -2506,8 +2690,9 @@
     },
     "node_modules/charm": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/charm/-/charm-1.0.2.tgz",
+      "integrity": "sha512-wqW3VdPnlSWT4eRiYX+hcs+C6ViBPUWk1qTCd+37qw9kEm/a5n2qcyQDMBWvSYKN/ctqZzeXNQaeBjOetJJUkw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1"
       }
@@ -2523,11 +2708,13 @@
     },
     "node_modules/client-only": {
       "version": "0.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "node_modules/clsx": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
       "engines": {
         "node": ">=6"
       }
@@ -2561,7 +2748,8 @@
     },
     "node_modules/commander": {
       "version": "7.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "engines": {
         "node": ">= 10"
       }
@@ -2596,8 +2784,9 @@
     },
     "node_modules/csstype": {
       "version": "3.1.1",
-      "devOptional": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2607,7 +2796,8 @@
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "engines": {
         "node": ">= 12"
       }
@@ -2675,8 +2865,9 @@
       "dev": true
     },
     "node_modules/deepmerge": {
-      "version": "4.2.2",
-      "license": "MIT",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2716,7 +2907,8 @@
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/diff": {
       "version": "5.1.0",
@@ -2752,7 +2944,8 @@
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -2763,25 +2956,28 @@
       }
     },
     "node_modules/dom7": {
-      "version": "4.0.4",
-      "license": "MIT",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.6.tgz",
+      "integrity": "sha512-emjdpPLhpNubapLFdjNL9tP06Sr+GZkrIHEXLWvOGsytACUrkbeIdjO5g77m00BrHTznnlcNqgmn7pCN192TBA==",
       "dependencies": {
         "ssr-window": "^4.0.0"
       }
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
-      ],
-      "license": "BSD-2-Clause"
+      ]
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -2794,7 +2990,8 @@
     },
     "node_modules/domutils": {
       "version": "3.0.1",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -2805,9 +3002,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.316",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.316.tgz",
-      "integrity": "sha512-9urqVpdeJYAwVL/sBjsX2pSlgYI/b4nOqC6UaNa0xlq1VUbXLRhERWlxcQ4FWfUOQQxSSxN/taFtapEcwg5tVA==",
+      "version": "1.4.342",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.342.tgz",
+      "integrity": "sha512-dTei3VResi5bINDENswBxhL+N0Mw5YnfWyTqO75KGsVldurEkhC9+CelJVAse8jycWyP8pv3VSj4BSyP8wTWJA==",
       "peer": true
     },
     "node_modules/emoji-regex": {
@@ -2830,7 +3027,8 @@
     },
     "node_modules/entities": {
       "version": "4.4.0",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
       "engines": {
         "node": ">=0.12"
       },
@@ -2839,18 +3037,18 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
-      "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+      "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
       "dev": true,
       "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "get-symbol-description": "^1.0.0",
         "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
@@ -2858,8 +3056,8 @@
         "has-property-descriptors": "^1.0.0",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.4",
-        "is-array-buffer": "^3.0.1",
+        "internal-slot": "^1.0.5",
+        "is-array-buffer": "^3.0.2",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
@@ -2867,11 +3065,12 @@
         "is-string": "^1.0.7",
         "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.2",
+        "object-inspect": "^1.12.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
         "safe-regex-test": "^1.0.0",
+        "string.prototype.trim": "^1.2.7",
         "string.prototype.trimend": "^1.0.6",
         "string.prototype.trimstart": "^1.0.6",
         "typed-array-length": "^1.0.4",
@@ -2962,7 +3161,8 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
         "node": ">=10"
       },
@@ -2971,12 +3171,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.34.0.tgz",
-      "integrity": "sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==",
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.37.0.tgz",
+      "integrity": "sha512-NU3Ps9nI05GUoVMxcZx1J8CNR6xOvUT4jAUMH5+z8lpp3aEdPVCImKw6PWG4PY+Vfkpr+jvMpxs/qoE7wq0sPw==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.4.1",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.0.2",
+        "@eslint/js": "8.37.0",
         "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -2987,10 +3190,9 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.4.0",
-        "esquery": "^1.4.0",
+        "eslint-visitor-keys": "^3.4.0",
+        "espree": "^9.5.1",
+        "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
@@ -3011,7 +3213,6 @@
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
@@ -3027,12 +3228,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.1.6.tgz",
-      "integrity": "sha512-0cg7h5wztg/SoLAlxljZ0ZPUQ7i6QKqRiP4M2+MgTZtxWwNKb2JSwNc18nJ6/kXBI6xYvPraTbQSIhAuVw6czw==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.2.4.tgz",
+      "integrity": "sha512-lunIBhsoeqw6/Lfkd6zPt25w1bn0znLA/JCL+au1HoEpSb4/PpsOYsYtgV/q+YPsoKIOzFyU5xnb04iZnXjUvg==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "13.1.6",
+        "@next/eslint-plugin-next": "13.2.4",
         "@rushstack/eslint-patch": "^1.1.3",
         "@typescript-eslint/parser": "^5.42.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -3053,9 +3254,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
-      "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -3317,15 +3518,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eslint-plugin-react/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
       "version": "2.0.0-next.4",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
@@ -3380,40 +3572,24 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
+    "node_modules/eslint-scope/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
-    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
+        "node": ">=4.0"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
@@ -3429,24 +3605,15 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/eslint/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/espree": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
+      "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3456,24 +3623,15 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
-      "integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/esquery/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/esrecurse": {
@@ -3487,18 +3645,10 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/esrecurse/node_modules/estraverse": {
+    "node_modules/estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "engines": {
         "node": ">=4.0"
       }
@@ -3651,6 +3801,8 @@
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
       "funding": [
         {
           "type": "github",
@@ -3661,7 +3813,6 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -3736,13 +3887,14 @@
     },
     "node_modules/follow-redirects": {
       "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -3763,7 +3915,8 @@
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -3772,11 +3925,10 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "8.5.4",
-      "license": "MIT",
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.9.4.tgz",
+      "integrity": "sha512-x3tYEKI+pTG43LdXjJe4Cu2VjTwW+XkQ0Uc3ByNbze5kny8Y/x0Bq+18wsBwKgCRBFZxltUeOpBBjLz0tg8lEA==",
       "dependencies": {
-        "@motionone/dom": "^10.15.3",
-        "hey-listen": "^1.0.8",
         "tslib": "^2.4.0"
       },
       "optionalDependencies": {
@@ -3785,6 +3937,14 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs.realpath": {
@@ -3842,7 +4002,8 @@
     },
     "node_modules/get-nonce": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
       "engines": {
         "node": ">=6"
       }
@@ -3864,24 +4025,24 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.4.0.tgz",
-      "integrity": "sha512-0Gdjo/9+FzsYhXCEFueo2aY1z1tpXrxWZzP7k8ul9qt1U5o8rYJwTJYmaeHdrVosYIVYkOy2iwCJ9FdpocJhPQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.5.0.tgz",
+      "integrity": "sha512-MjhiaIWCJ1sAU4pIQ5i5OfOuHHxVo1oYeNsWTON7jxYkod8pHocXeh+SSbmu5OZZZK73B6cbJ2XADzXehLyovQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
+        "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -3985,9 +4146,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -4110,24 +4271,24 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hey-listen": {
-      "version": "1.0.8",
-      "license": "MIT"
-    },
     "node_modules/hls.js": {
-      "version": "1.3.1",
-      "license": "Apache-2.0"
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.3.5.tgz",
+      "integrity": "sha512-uybAvKS6uDe0MnWNEPnO0krWVr+8m2R0hJ/viql8H3MVK+itq8gGQuIYoFHL3rECkIpNH98Lw8YuuWMKZxp3Ew=="
     },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
       "optional": true,
       "dependencies": {
         "void-elements": "3.1.0"
       }
     },
     "node_modules/htmlparser2": {
-      "version": "8.0.1",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -4135,16 +4296,17 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
+        "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
-        "entities": "^4.3.0"
+        "entities": "^4.4.0"
       }
     },
     "node_modules/i18next": {
-      "version": "22.4.9",
+      "version": "22.4.13",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.4.13.tgz",
+      "integrity": "sha512-GX7flMHRRqQA0I1yGLmaZ4Hwt1JfLqagk8QPDPZsqekbKtXsuIngSVWM/s3SLgNkrEXjA+0sMGNuOEkkmyqmWg==",
       "funding": [
         {
           "type": "individual",
@@ -4159,7 +4321,6 @@
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
         }
       ],
-      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -4212,8 +4373,9 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/inline-style-parser": {
       "version": "0.1.1",
@@ -4236,7 +4398,8 @@
     },
     "node_modules/invariant": {
       "version": "2.2.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -4280,13 +4443,13 @@
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
-      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "is-typed-array": "^1.1.10"
       },
       "funding": {
@@ -4503,7 +4666,8 @@
     },
     "node_modules/is-plain-object": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4690,9 +4854,9 @@
       }
     },
     "node_modules/js-sdsl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
-      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
+      "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -4701,7 +4865,8 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -4782,7 +4947,8 @@
     },
     "node_modules/leaflet": {
       "version": "1.9.3",
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.3.tgz",
+      "integrity": "sha512-iB2cR9vAkDOu5l3HAay2obcUHZ7xwUBBjph8+PGtmW/2lYhbLizWtG7nTeYht36WfOslixQF9D/uSIzhZgGMfQ=="
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -4823,7 +4989,8 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -4842,7 +5009,8 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -5678,7 +5846,8 @@
     },
     "node_modules/mitt": {
       "version": "3.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -5694,8 +5863,15 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "license": "MIT",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -5722,10 +5898,11 @@
       "peer": true
     },
     "node_modules/next": {
-      "version": "13.1.5",
-      "license": "MIT",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.2.4.tgz",
+      "integrity": "sha512-g1I30317cThkEpvzfXujf0O4wtaQHtDCLhlivwlTJ885Ld+eOgcz7r3TGQzeU+cSRoNHtD8tsJgzxVdYojFssw==",
       "dependencies": {
-        "@next/env": "13.1.5",
+        "@next/env": "13.2.4",
         "@swc/helpers": "0.4.14",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
@@ -5738,21 +5915,22 @@
         "node": ">=14.6.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "13.1.5",
-        "@next/swc-android-arm64": "13.1.5",
-        "@next/swc-darwin-arm64": "13.1.5",
-        "@next/swc-darwin-x64": "13.1.5",
-        "@next/swc-freebsd-x64": "13.1.5",
-        "@next/swc-linux-arm-gnueabihf": "13.1.5",
-        "@next/swc-linux-arm64-gnu": "13.1.5",
-        "@next/swc-linux-arm64-musl": "13.1.5",
-        "@next/swc-linux-x64-gnu": "13.1.5",
-        "@next/swc-linux-x64-musl": "13.1.5",
-        "@next/swc-win32-arm64-msvc": "13.1.5",
-        "@next/swc-win32-ia32-msvc": "13.1.5",
-        "@next/swc-win32-x64-msvc": "13.1.5"
+        "@next/swc-android-arm-eabi": "13.2.4",
+        "@next/swc-android-arm64": "13.2.4",
+        "@next/swc-darwin-arm64": "13.2.4",
+        "@next/swc-darwin-x64": "13.2.4",
+        "@next/swc-freebsd-x64": "13.2.4",
+        "@next/swc-linux-arm-gnueabihf": "13.2.4",
+        "@next/swc-linux-arm64-gnu": "13.2.4",
+        "@next/swc-linux-arm64-musl": "13.2.4",
+        "@next/swc-linux-x64-gnu": "13.2.4",
+        "@next/swc-linux-x64-musl": "13.2.4",
+        "@next/swc-win32-arm64-msvc": "13.2.4",
+        "@next/swc-win32-ia32-msvc": "13.2.4",
+        "@next/swc-win32-x64-msvc": "13.2.4"
       },
       "peerDependencies": {
+        "@opentelemetry/api": "^1.4.0",
         "fibers": ">= 3.1.0",
         "node-sass": "^6.0.0 || ^7.0.0",
         "react": "^18.2.0",
@@ -5760,6 +5938,9 @@
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
         "fibers": {
           "optional": true
         },
@@ -5773,11 +5954,13 @@
     },
     "node_modules/next-absolute-url": {
       "version": "1.2.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/next-absolute-url/-/next-absolute-url-1.2.2.tgz",
+      "integrity": "sha512-Z2+LZXQTthhw2je9u4eq8QWXxXd57a6b54x9exBfQX4Dct6YxaMjcXZWNLHd9AOlCue84EsMpdSGP7wACqUnPg=="
     },
     "node_modules/next-themes": {
       "version": "0.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
+      "integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
       "peerDependencies": {
         "next": "*",
         "react": "*",
@@ -5786,6 +5969,8 @@
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "funding": [
         {
           "type": "github",
@@ -5796,14 +5981,14 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.3.0",
-      "license": "MIT",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -5825,7 +6010,8 @@
     },
     "node_modules/node-webvtt": {
       "version": "1.9.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/node-webvtt/-/node-webvtt-1.9.4.tgz",
+      "integrity": "sha512-EjrJdKdxSyd8j4LMLW6s2Ah4yNoeVXp18Ob04CQl1In18xcUmKzEE8pcsxxnFVqanTyjbGYph2VnvtwIXR4EjA==",
       "dependencies": {
         "commander": "^7.1.0"
       },
@@ -5968,9 +6154,9 @@
       }
     },
     "node_modules/open": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.1.tgz",
-      "integrity": "sha512-/4b7qZNhv6Uhd7jjnREh1NjnPxlTq+XNWPG88Ydkj5AILcA5m3ajvcg57pB24EQjKv0dK62XnDqk9c/hkIG5Kg==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
@@ -5986,7 +6172,8 @@
     },
     "node_modules/openseadragon": {
       "version": "2.4.2",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/openseadragon/-/openseadragon-2.4.2.tgz",
+      "integrity": "sha512-398KbZwRtOYA6OmeWRY4Q0737NTacQ9Q6whmr9Lp1MNQO3p0eBz5LIASRne+4gwequcSM1vcHcjfy3dIndQziw=="
     },
     "node_modules/optionator": {
       "version": "0.9.1",
@@ -6068,11 +6255,13 @@
     },
     "node_modules/parse-srcset": {
       "version": "1.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
     },
     "node_modules/parse-svg-path": {
       "version": "0.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
       "optional": true
     },
     "node_modules/path-exists": {
@@ -6129,7 +6318,8 @@
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -6145,6 +6335,8 @@
     },
     "node_modules/postcss": {
       "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
       "funding": [
         {
           "type": "opencollective",
@@ -6155,7 +6347,6 @@
           "url": "https://tidelift.com/funding/github/npm/postcss"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -6241,7 +6432,8 @@
     },
     "node_modules/react": {
       "version": "18.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6251,7 +6443,8 @@
     },
     "node_modules/react-dom": {
       "version": "18.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -6262,7 +6455,8 @@
     },
     "node_modules/react-error-boundary": {
       "version": "3.1.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },
@@ -6276,7 +6470,8 @@
     },
     "node_modules/react-i18next": {
       "version": "11.18.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
+      "integrity": "sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.14.5",
@@ -6296,8 +6491,9 @@
       }
     },
     "node_modules/react-intersection-observer": {
-      "version": "9.4.1",
-      "license": "MIT",
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.4.3.tgz",
+      "integrity": "sha512-WNRqMQvKpupr6MzecAQI0Pj0+JQong307knLP4g/nBex7kYfIaZsPpXaIhKHR+oV8z+goUbH9e10j6lGRnTzlQ==",
       "peerDependencies": {
         "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
@@ -6309,8 +6505,9 @@
       "dev": true
     },
     "node_modules/react-leaflet": {
-      "version": "4.2.0",
-      "license": "Hippocratic-2.1",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
       "dependencies": {
         "@react-leaflet/core": "^2.1.0"
       },
@@ -6322,14 +6519,16 @@
     },
     "node_modules/react-masonry-css": {
       "version": "1.0.16",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-masonry-css/-/react-masonry-css-1.0.16.tgz",
+      "integrity": "sha512-KSW0hR2VQmltt/qAa3eXOctQDyOu7+ZBevtKgpNDSzT7k5LA/0XntNa9z9HKCdz3QlxmJHglTZ18e4sX4V8zZQ==",
       "peerDependencies": {
         "react": ">=16.0.0"
       }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.5.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+      "integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.3",
         "react-style-singleton": "^2.2.1",
@@ -6352,7 +6551,8 @@
     },
     "node_modules/react-remove-scroll-bar": {
       "version": "2.3.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+      "integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
       "dependencies": {
         "react-style-singleton": "^2.2.1",
         "tslib": "^2.0.0"
@@ -6372,7 +6572,8 @@
     },
     "node_modules/react-style-singleton": {
       "version": "2.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
       "dependencies": {
         "get-nonce": "^1.0.0",
         "invariant": "^2.2.4",
@@ -6392,15 +6593,17 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.0",
-      "license": "MIT",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -6417,18 +6620,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/remark-mdx": {
@@ -6593,8 +6784,9 @@
       }
     },
     "node_modules/sanitize-html": {
-      "version": "2.8.1",
-      "license": "MIT",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.10.0.tgz",
+      "integrity": "sha512-JqdovUd81dG4k87vZt6uA6YhDfWkUGruUu/aPmXLxXi45gZExnt9Bnw/qeQU8oGf82vPyaE0vO4aH0PbobB9JQ==",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
@@ -6606,7 +6798,8 @@
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -6698,8 +6891,9 @@
       }
     },
     "node_modules/slugify": {
-      "version": "1.6.5",
-      "license": "MIT",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6714,7 +6908,8 @@
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6749,7 +6944,8 @@
     },
     "node_modules/ssr-window": {
       "version": "4.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.0.0",
@@ -6777,6 +6973,23 @@
         "internal-slot": "^1.0.3",
         "regexp.prototype.flags": "^1.4.3",
         "side-channel": "^1.0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6866,7 +7079,8 @@
     },
     "node_modules/styled-jsx": {
       "version": "5.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
       "dependencies": {
         "client-only": "0.0.1"
       },
@@ -6911,11 +7125,14 @@
     },
     "node_modules/svg-arc-to-cubic-bezier": {
       "version": "3.2.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
       "optional": true
     },
     "node_modules/swiper": {
-      "version": "8.4.6",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-9.1.1.tgz",
+      "integrity": "sha512-D1zArOwI6XCXCYBULPA4jTxpqp5SQtvntjinbXNZwXzj6P3KS51zSWuMarCLXq5oRISay4nX+TuShpxz8qhtbw==",
       "funding": [
         {
           "type": "patreon",
@@ -6926,10 +7143,7 @@
           "url": "http://opencollective.com/swiper"
         }
       ],
-      "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
-        "dom7": "^4.0.4",
         "ssr-window": "^4.0.2"
       },
       "engines": {
@@ -6961,9 +7175,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.16.5",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.5.tgz",
-      "integrity": "sha512-qcwfg4+RZa3YvlFh0qjifnzBHjKGNbtDo9yivMqMFDy9Q6FSaQWSB/j1xKhsoUFJIqDOM3TsN6D5xbrMrFcHbg==",
+      "version": "5.16.8",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.8.tgz",
+      "integrity": "sha512-QI5g1E/ef7d+PsDifb+a6nnVgC4F22Bg6T0xrBrz6iloVB4PUkkunp6V8nzoOOZJIzjWVdAGqCdlKlhLq/TbIA==",
       "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -6979,16 +7193,16 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
-      "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz",
+      "integrity": "sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==",
       "peer": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.14",
+        "@jridgewell/trace-mapping": "^0.3.17",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.0",
-        "terser": "^5.14.1"
+        "serialize-javascript": "^6.0.1",
+        "terser": "^5.16.5"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -7036,7 +7250,8 @@
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -7074,20 +7289,21 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
+      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
       "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
+        "json5": "^1.0.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
     },
     "node_modules/tslib": {
       "version": "2.5.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -7150,21 +7366,23 @@
     },
     "node_modules/typesafe-actions": {
       "version": "5.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/typesafe-actions/-/typesafe-actions-5.1.0.tgz",
+      "integrity": "sha512-bna6Yi1pRznoo6Bz1cE6btB/Yy8Xywytyfrzu/wc+NFW3ZF0I+2iCGImhBsoYYCOWuICtRO4yHcnDlzgo1AdNg==",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/unbox-primitive": {
@@ -7333,7 +7551,8 @@
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -7352,7 +7571,8 @@
     },
     "node_modules/use-isomorphic-layout-effect": {
       "version": "1.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       },
@@ -7364,7 +7584,8 @@
     },
     "node_modules/use-sidecar": {
       "version": "1.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
       "dependencies": {
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"
@@ -7384,7 +7605,8 @@
     },
     "node_modules/uuid": {
       "version": "9.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -7449,7 +7671,8 @@
     },
     "node_modules/void-elements": {
       "version": "3.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -7470,15 +7693,16 @@
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+      "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
       "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -7648,7 +7872,9 @@
   },
   "dependencies": {
     "@atlas-viewer/iiif-image-api": {
-      "version": "2.1.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@atlas-viewer/iiif-image-api/-/iiif-image-api-2.1.1.tgz",
+      "integrity": "sha512-g7gleRz0Guxwj/JqtppiqloabUTCew61GBzon+ZZ7mXpnMQ+zMupLaI1jHfGxM1Xy9a1+zMwPuUTXqTFkEyueA==",
       "peer": true,
       "requires": {
         "@iiif/presentation-3": "*",
@@ -7656,13 +7882,17 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.20.13",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
     },
     "@emotion/is-prop-valid": {
       "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
       "optional": true,
       "requires": {
         "@emotion/memoize": "0.7.4"
@@ -7670,17 +7900,34 @@
     },
     "@emotion/memoize": {
       "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
       "optional": true
     },
+    "@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "@eslint-community/regexpp": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
+      "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+      "dev": true
+    },
     "@eslint/eslintrc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-      "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
+      "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.4.0",
+        "espree": "^9.5.1",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -7689,17 +7936,29 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@eslint/js": {
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.37.0.tgz",
+      "integrity": "sha512-x5vzdtOOGgFVDCUs81QRB2+liax8rFg3+7hqM+QhBG0/G3F1ZsoYl97UrqgHgQ9KKT7G6c4V+aTUCgu/n22v1A==",
+      "dev": true
+    },
     "@floating-ui/core": {
-      "version": "0.7.3"
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.7.3.tgz",
+      "integrity": "sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg=="
     },
     "@floating-ui/dom": {
       "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.5.4.tgz",
+      "integrity": "sha512-419BMceRLq0RrmTSDxn8hf9R3VCJv2K9PUfugh5JyEFmdjzDo+e8U5EdR8nzKq8Yj1htzLm3b6eQEEam3/rrtg==",
       "requires": {
         "@floating-ui/core": "^0.7.3"
       }
     },
     "@floating-ui/react-dom": {
       "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-0.7.2.tgz",
+      "integrity": "sha512-1T0sJcpHgX/u4I1OzIEhlcrvkUN8ln39nz7fMoE/2HDHrPiMFoOGR7++GYyfUmIQHkkrTinaeQsO3XWubjSvGg==",
       "requires": {
         "@floating-ui/dom": "^0.5.3",
         "use-isomorphic-layout-effect": "^1.1.1"
@@ -7740,6 +7999,8 @@
     },
     "@iiif/presentation-2": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@iiif/presentation-2/-/presentation-2-1.0.4.tgz",
+      "integrity": "sha512-hJakpq62VBajesLJrYPtFm6hcn6c/HkKP7CmKZ5atuzu40m0nifWYsqigR1l9sZGvhhHb/DRshPmiW/0GNrJoA==",
       "requires": {}
     },
     "@iiif/presentation-3": {
@@ -7766,9 +8027,9 @@
       }
     },
     "@iiif/vault-helpers": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.9.11.tgz",
-      "integrity": "sha512-4XuFPvu233mMzfU/mMpAqFY5aCTzwhJ0u7MzPcpN8nSfMwbV5Dyvv0PppjcocvbWMUUXScqerRoB1MAfSFas6w==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.10.0.tgz",
+      "integrity": "sha512-gnjTPcZJMIDjwU5K8HYNU8Iix49Awmsr7IhIyxA5ZCqugnLjHvJUOmOvT7q1NRd6ia4+09wxx+EMH0D9mt4cxQ==",
       "requires": {
         "@iiif/presentation-2": "1.x",
         "@iiif/presentation-3": "1.x",
@@ -7860,164 +8121,104 @@
         "vfile": "^5.0.0"
       }
     },
-    "@motionone/animation": {
-      "version": "10.15.1",
-      "requires": {
-        "@motionone/easing": "^10.15.1",
-        "@motionone/types": "^10.15.1",
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@motionone/dom": {
-      "version": "10.15.5",
-      "requires": {
-        "@motionone/animation": "^10.15.1",
-        "@motionone/generators": "^10.15.1",
-        "@motionone/types": "^10.15.1",
-        "@motionone/utils": "^10.15.1",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@motionone/easing": {
-      "version": "10.15.1",
-      "requires": {
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@motionone/generators": {
-      "version": "10.15.1",
-      "requires": {
-        "@motionone/types": "^10.15.1",
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@motionone/types": {
-      "version": "10.15.1"
-    },
-    "@motionone/utils": {
-      "version": "10.15.1",
-      "requires": {
-        "@motionone/types": "^10.15.1",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
-      }
-    },
     "@next/env": {
-      "version": "13.1.5"
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.2.4.tgz",
+      "integrity": "sha512-+Mq3TtpkeeKFZanPturjcXt+KHfKYnLlX6jMLyCrmpq6OOs4i1GqBOAauSkii9QeKCMTYzGppar21JU57b/GEA=="
     },
     "@next/eslint-plugin-next": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.1.6.tgz",
-      "integrity": "sha512-o7cauUYsXjzSJkay8wKjpKJf2uLzlggCsGUkPu3lP09Pv97jYlekTC20KJrjQKmSv5DXV0R/uks2ZXhqjNkqAw==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.2.4.tgz",
+      "integrity": "sha512-ck1lI+7r1mMJpqLNa3LJ5pxCfOB1lfJncKmRJeJxcJqcngaFwylreLP7da6Rrjr6u2gVRTfmnkSkjc80IiQCwQ==",
       "dev": true,
       "requires": {
         "glob": "7.1.7"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "@next/mdx": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-13.2.3.tgz",
-      "integrity": "sha512-4xo0wF6FMrtQI7587Z6pbXd6crtGJI3axZ2kxbxCNC0osjlLUSeCNg2lahi8JTEpyc0+KH6B0e0bhsymTMkw7Q==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-13.2.4.tgz",
+      "integrity": "sha512-inl7u+OEa4Ok3uL052oa8EDw1bUkMGLVKzFfVBIgG19s29gxQvcWYzxa5t438J31ljApjh6Y5k4AD6yLaCAlQw==",
       "requires": {
         "source-map": "^0.7.0"
       }
     },
     "@next/swc-android-arm-eabi": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.1.5.tgz",
-      "integrity": "sha512-QAEf3YM9U0qWVQTxgF3Tsh4OeCN1i9Smsf6cVlwZsPzoLyj2nQ879joCoN+ONqDknkBgG6OG/ajefywL3jw9Cg==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz",
+      "integrity": "sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==",
       "optional": true
     },
     "@next/swc-android-arm64": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.1.5.tgz",
-      "integrity": "sha512-ZmtGPTghRuT5YKL0nNcC2bBVSiG1O0is16eIZ2rWSP/hRW64ZCcAew6pxw2rihntNp22UfequjSTHd91WE/tyQ==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.4.tgz",
+      "integrity": "sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==",
       "optional": true
     },
     "@next/swc-darwin-arm64": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.1.5.tgz",
-      "integrity": "sha512-aeFXK+M/zmG/CNdMJ0tGNs0MWcLueUe7vZ2V6fa+2yz/ZgYJLI7fEfFvVh1p1yBMzupSbZDowvMuCSFTaeg3MA==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.4.tgz",
+      "integrity": "sha512-S6vBl+OrInP47TM3LlYx65betocKUUlTZDDKzTiRDbsRESeyIkBtZ6Qi5uT2zQs4imqllJznVjFd1bXLx3Aa6A==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.1.5.tgz",
-      "integrity": "sha512-6mPX0GNRg8NzjV70at8I8pD9YBnPHDpxJCoMuIqysdTjtQhd09Xk6GUhquNhp1kEJzzVk7OW5l2ch4XIJjtY3A==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.4.tgz",
+      "integrity": "sha512-a6LBuoYGcFOPGd4o8TPo7wmv5FnMr+Prz+vYHopEDuhDoMSHOnC+v+Ab4D7F0NMZkvQjEJQdJS3rqgFhlZmKlw==",
       "optional": true
     },
     "@next/swc-freebsd-x64": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.1.5.tgz",
-      "integrity": "sha512-nR4a/SNblG0w8hhYRflTZjk4yD99ld18w/FCftw99ziw8sgciBlOXRICJIiRIaMRU8UH7QLSgBOQVnfNcVNKMA==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.4.tgz",
+      "integrity": "sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==",
       "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.1.5.tgz",
-      "integrity": "sha512-EzkltCVKg3gUzamoeKPhGeSgXTTLAhSzc7v/+g1Y+HQa7JKMrlzdRkrJf+H4LJXcz7lnxgNKHGRyZBSXnmJKJw==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.4.tgz",
+      "integrity": "sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.1.5.tgz",
-      "integrity": "sha512-E7HMkdoxStmTUJU4KzBUU4vZ5DHT4Gd327tC3KFZS5lda0NRerJAOCfsRg+fBj22FvCb1UWsX6XI+weL6xhyeQ==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.4.tgz",
+      "integrity": "sha512-xzYZdAeq883MwXgcwc72hqo/F/dwUxCukpDOkx/j1HTq/J0wJthMGjinN9wH5bPR98Mfeh1MZJ91WWPnZOedOg==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.1.5.tgz",
-      "integrity": "sha512-qlO0Fd3GQwJS6YpbF9NyL5NGHVZ43dKtZDC/jP4vdeMIYDtSu13HcY/nmA1NdW+RpMwDxSCpx4WKsCCEZGIX8Q==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.4.tgz",
+      "integrity": "sha512-8rXr3WfmqSiYkb71qzuDP6I6R2T2tpkmf83elDN8z783N9nvTJf2E7eLx86wu2OJCi4T05nuxCsh4IOU3LQ5xw==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.1.5.tgz",
-      "integrity": "sha512-GftSBFAay2nocGl+KNqFsj6EVSvomaM/bp86hzezbKsTwQmu76PjOCVcejI1gE+4k7f5zPDgCuorF6F04BV0HQ==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.4.tgz",
+      "integrity": "sha512-Ngxh51zGSlYJ4EfpKG4LI6WfquulNdtmHg1yuOYlaAr33KyPJp4HeN/tivBnAHcZkoNy0hh/SbwDyCnz5PFJQQ==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.1.5.tgz",
-      "integrity": "sha512-UD+3lxU4yuAjd+uBkCDfBpAcbGAVfEcE8mX/efIxUGIImmzN0QzgTHYEpKFnY3Lxu02dIBcwQRT3Q5mfO4obng==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.4.tgz",
+      "integrity": "sha512-gOvwIYoSxd+j14LOcvJr+ekd9fwYT1RyMAHOp7znA10+l40wkFiMONPLWiZuHxfRk+Dy7YdNdDh3ImumvL6VwA==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.1.5.tgz",
-      "integrity": "sha512-uzsvkQY+K3EbL+97IUHPWZPwjsCmCkdH/O5Cf9wCnh0k0gaj7ob1mGKqr1vNNak+9U7HloGwuHcXnZpijWSP7w==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.4.tgz",
+      "integrity": "sha512-q3NJzcfClgBm4HvdcnoEncmztxrA5GXqKeiZ/hADvC56pwNALt3ngDC6t6qr1YW9V/EPDxCYeaX4zYxHciW4Dw==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.1.5.tgz",
-      "integrity": "sha512-v0NaC1w8mPf620GlJaHBdEm3dm4G4AEQMasDqjzQvo0yCRrvtvzMgCIe8MocBxFHzaF6868NybMqvumxP5YxEg==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.4.tgz",
+      "integrity": "sha512-/eZ5ncmHUYtD2fc6EUmAIZlAJnVT2YmxDsKs1Ourx0ttTtvtma/WKlMV5NoUsyOez0f9ExLyOpeCoz5aj+MPXw==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.1.5.tgz",
-      "integrity": "sha512-IZHwvd649ccbWyLCfu92IXEpR250NpmBkaRelPV+WVm4jrd62FKRFCNdqdCXq6TrEg9wN8cK4YG8tm44uEZqLA==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.4.tgz",
+      "integrity": "sha512-0MffFmyv7tBLlji01qc0IaPP/LVExzvj7/R5x1Jph1bTAIj4Vu81yFQWHHQAP6r4ff9Ukj1mBK6MDNVXm7Tcvw==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -8047,7 +8248,9 @@
       }
     },
     "@nulib/design-system": {
-      "version": "1.6.1",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@nulib/design-system/-/design-system-1.6.2.tgz",
+      "integrity": "sha512-tY3lxsfvh9fcNiEa/+o3C9gatRwA38UBMsfWIG2g2NeD4IzOnUmKgNr1FE1O7xxsHMAtIJuQ/A2dtMbWAJwNbw==",
       "requires": {
         "@radix-ui/react-popover": "^0.1.7-rc.43",
         "@stitches/react": "^1.2.7",
@@ -8075,65 +8278,103 @@
     },
     "@radix-ui/number": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.0.tgz",
+      "integrity": "sha512-Ofwh/1HX69ZfJRiRBMTy7rgjAzHmwe4kW9C9Y99HTRUcYLUuVT0KESFj15rPjRgKJs20GPq8Bm5aEDJ8DuA3vA==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/primitive": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
+      "integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-accordion": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.1.0.tgz",
-      "integrity": "sha512-CNN9ZBgCK4i4SX7gFk5s8095j55DUWi85vwRNfkfBLs0QdAG5Tb4ku6sBeugCAiLvsmxw481GyNl+C3stoJVBQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.1.1.tgz",
+      "integrity": "sha512-TQtyyRubYe8DD6DYCovNLTjd2D+TFrNCpr99T5M3cYUbR7BsRxWsxfInjbQ1nHsdy2uPTcnJS5npyXPVfP0piw==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-collapsible": "1.0.1",
-        "@radix-ui/react-collection": "1.0.1",
+        "@radix-ui/react-collapsible": "1.0.2",
+        "@radix-ui/react-collection": "1.0.2",
         "@radix-ui/react-compose-refs": "1.0.0",
         "@radix-ui/react-context": "1.0.0",
         "@radix-ui/react-direction": "1.0.0",
         "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-use-controllable-state": "1.0.0"
       }
     },
     "@radix-ui/react-arrow": {
-      "version": "1.0.1",
+      "version": "0.1.5-rc.47",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-0.1.5-rc.47.tgz",
+      "integrity": "sha512-qx8Ky3FvWHrd6zHTUwvBk83tAbbzqPrXfFor9O31aE91nZIFyMlPo56OkpiRc/rI+4GxbimB/vxVq8UFz2liCg==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-primitive": "1.0.1"
+        "@radix-ui/react-primitive": "0.1.5-rc.47"
+      },
+      "dependencies": {
+        "@radix-ui/react-compose-refs": {
+          "version": "0.1.1-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.1-rc.47.tgz",
+          "integrity": "sha512-FJRPt4lAfYEFVc5XfIa1ICprJNGjldbRN6v3NsQVZjNcStQcgFaNvvKzvaUyJS7SwNip0F5Inm7wX7aXOEjxiQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10"
+          }
+        },
+        "@radix-ui/react-primitive": {
+          "version": "0.1.5-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.5-rc.47.tgz",
+          "integrity": "sha512-eLpWe5H3YoLUjmAERxRQSBjWwu1yhhgljUcxdZMisGBEZNDrRF4Kg1oQvOGJTvQNQ/gUqD784MkbOP6woFcqzg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-slot": "0.1.3-rc.47"
+          }
+        },
+        "@radix-ui/react-slot": {
+          "version": "0.1.3-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.3-rc.47.tgz",
+          "integrity": "sha512-nurUm75+/nb38nKpHjMqc4GNTDTbDu6KYDdZVJOm+sChaUDVFSdYTHC4A1c9R7k7vtrytFV/obTCc8pqEkU4Gg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-compose-refs": "0.1.1-rc.47"
+          }
+        }
       }
     },
     "@radix-ui/react-aspect-ratio": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.0.2.tgz",
+      "integrity": "sha512-YCujQYnwcVcakbdhE8eTjhh4QR8CsngEcRlSzIPWw1vp3KPC9orETo8CxuVM65j5HAp0oFoOlIy6v7SuF+9P+Q==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-primitive": "1.0.1"
+        "@radix-ui/react-primitive": "1.0.2"
       }
     },
     "@radix-ui/react-checkbox": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.0.1.tgz",
-      "integrity": "sha512-TisH0B8hWmYP3ONRduYCyN04rR9yLPIw/Rwyn1RoC1suSoGCa8Wn+YPdSSSarSszeIbcg3p2lBkDp2XXit4sZw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.0.3.tgz",
+      "integrity": "sha512-55B8/vKzTuzxllH5sGJO4zaBf9gYpJuJRRzaOKm+0oAefRnMvbf+Kgww7IOANVN0w3z7agFJgtnXaZl8Uj95AA==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
         "@radix-ui/react-compose-refs": "1.0.0",
         "@radix-ui/react-context": "1.0.0",
         "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-use-controllable-state": "1.0.0",
         "@radix-ui/react-use-previous": "1.0.0",
         "@radix-ui/react-use-size": "1.0.0"
       }
     },
     "@radix-ui/react-collapsible": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.0.2.tgz",
+      "integrity": "sha512-QNiDT6Au8jUU0K1WV+HEd4loH7C5CKQjeXxskwqyiyAkyCmW7qlQM5vSSJCIoQC+OVPyhgafSmGudRP8Qm1/gA==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
@@ -8141,49 +8382,55 @@
         "@radix-ui/react-context": "1.0.0",
         "@radix-ui/react-id": "1.0.0",
         "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-use-controllable-state": "1.0.0",
         "@radix-ui/react-use-layout-effect": "1.0.0"
       }
     },
     "@radix-ui/react-collection": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.2.tgz",
+      "integrity": "sha512-s8WdQQ6wNXpaxdZ308KSr8fEWGrg4un8i4r/w7fhiS4ElRNjk5rRcl0/C6TANG2LvLOGIxtzo/jAg6Qf73TEBw==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "1.0.0",
         "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-slot": "1.0.1"
       }
     },
     "@radix-ui/react-compose-refs": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-context": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
+      "integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-dialog": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.2.tgz",
-      "integrity": "sha512-EKxxp2WNSmUPkx4trtWNmZ4/vAYEg7JkAfa1HKBUnaubw9eHzf1Orr9B472lJYaYz327RHDrd4R95fsw7VR8DA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.3.tgz",
+      "integrity": "sha512-owNhq36kNPqC2/a+zJRioPg6HHnTn5B/sh/NjTY8r4W9g1L5VJlrzZIVcBr7R9Mg8iLjVmh6MGgMlfoVf/WO/A==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
         "@radix-ui/react-compose-refs": "1.0.0",
         "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-dismissable-layer": "1.0.2",
+        "@radix-ui/react-dismissable-layer": "1.0.3",
         "@radix-ui/react-focus-guards": "1.0.0",
-        "@radix-ui/react-focus-scope": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.2",
         "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-portal": "1.0.1",
+        "@radix-ui/react-portal": "1.0.2",
         "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-slot": "1.0.1",
         "@radix-ui/react-use-controllable-state": "1.0.0",
         "aria-hidden": "^1.1.1",
@@ -8192,42 +8439,54 @@
     },
     "@radix-ui/react-direction": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
+      "integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-dismissable-layer": {
-      "version": "1.0.2",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.3.tgz",
+      "integrity": "sha512-nXZOvFjOuHS1ovumntGV7NNoLaEp9JEvTht3MBjP44NSW5hUKj/8OnfN3+8WmB+CEhN44XaGhpHoSsUIEl5P7Q==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
         "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-use-callback-ref": "1.0.0",
         "@radix-ui/react-use-escape-keydown": "1.0.2"
       }
     },
     "@radix-ui/react-focus-guards": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.0.tgz",
+      "integrity": "sha512-UagjDk4ijOAnGu4WMUPj9ahi7/zJJqNZ9ZAiGPp7waUWJO0O1aWXi/udPphI0IUjvrhBsZJGSN66dR2dsueLWQ==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-focus-scope": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.2.tgz",
+      "integrity": "sha512-spwXlNTfeIprt+kaEWE/qYuYT3ZAqJiAGjN/JgdvgVDTu8yc+HuX+WOWXrKliKnLnwck0F6JDkqIERncnih+4A==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-use-callback-ref": "1.0.0"
       }
     },
     "@radix-ui/react-icons": {
-      "version": "1.1.1",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.0.tgz",
+      "integrity": "sha512-jQxj/0LKgp+j9BiTXz3O3sgs26RNet2iLWmsPyRz2SIcR4q/4SbazXfnYwbAr+vLYKSfc7qxzyGQA1HLlYiuNw==",
       "requires": {}
     },
     "@radix-ui/react-id": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
+      "integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-layout-effect": "1.0.0"
@@ -8235,6 +8494,8 @@
     },
     "@radix-ui/react-popover": {
       "version": "0.1.7-rc.47",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-0.1.7-rc.47.tgz",
+      "integrity": "sha512-gzb5laGG4mHTcBFs8VK6ybE7F3uzr/Q+7QJjjGvLL7FI/eV0t9bkWKSJgrvDEXKfjLnSFjZZ80lYcEuuGf6xXw==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "0.1.1-rc.7",
@@ -8256,31 +8517,32 @@
       "dependencies": {
         "@radix-ui/primitive": {
           "version": "0.1.1-rc.7",
+          "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-0.1.1-rc.7.tgz",
+          "integrity": "sha512-JA0hJY7t2ZACmziHmtO85b5f1haxt9ptWJN9wdVePehfui3ZS3SqpL4asA6lRvvpiLDOl+0y6i69siHpeoUtgA==",
           "requires": {
             "@babel/runtime": "^7.13.10"
           }
         },
-        "@radix-ui/react-arrow": {
-          "version": "0.1.5-rc.47",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@radix-ui/react-primitive": "0.1.5-rc.47"
-          }
-        },
         "@radix-ui/react-compose-refs": {
           "version": "0.1.1-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.1-rc.47.tgz",
+          "integrity": "sha512-FJRPt4lAfYEFVc5XfIa1ICprJNGjldbRN6v3NsQVZjNcStQcgFaNvvKzvaUyJS7SwNip0F5Inm7wX7aXOEjxiQ==",
           "requires": {
             "@babel/runtime": "^7.13.10"
           }
         },
         "@radix-ui/react-context": {
           "version": "0.1.2-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-0.1.2-rc.47.tgz",
+          "integrity": "sha512-0FphpYHmFDKXnxBGgshj0rxDTkws0OfxJ+9ozYtKLDXZ0XLfTt4iTdtjCz8bq7y/6NTa58xnydooGMvR0sVibw==",
           "requires": {
             "@babel/runtime": "^7.13.10"
           }
         },
         "@radix-ui/react-dismissable-layer": {
           "version": "0.1.6-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-0.1.6-rc.47.tgz",
+          "integrity": "sha512-XVU5Mv4Un5AL07ZlAFYU2jn7ZZHeTSAH32WGK+9Ok4RpwPW2QUILCaYSyS+kYaOUOgRXa+TmUNy63adui0jjXw==",
           "requires": {
             "@babel/runtime": "^7.13.10",
             "@radix-ui/primitive": "0.1.1-rc.7",
@@ -8292,12 +8554,16 @@
         },
         "@radix-ui/react-focus-guards": {
           "version": "0.1.1-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-0.1.1-rc.47.tgz",
+          "integrity": "sha512-rvLQstRn6nxeCL79VGubLV+r9Z+lhZ1M/n2p2YQyF6ShdU8mJJIw805POqMhqNPv0S/ntf9oX3YIGrNnWj1vhw==",
           "requires": {
             "@babel/runtime": "^7.13.10"
           }
         },
         "@radix-ui/react-focus-scope": {
           "version": "0.1.5-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-0.1.5-rc.47.tgz",
+          "integrity": "sha512-pbNMSJ125C2df+A834vM4pg8iUNieiEbQVre/Uq/Ipke1VHkyItPbZ2/skIDTuJOSA4MecEeI/70ZbW6uNaS/g==",
           "requires": {
             "@babel/runtime": "^7.13.10",
             "@radix-ui/react-compose-refs": "0.1.1-rc.47",
@@ -8307,28 +8573,17 @@
         },
         "@radix-ui/react-id": {
           "version": "0.1.6-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.6-rc.47.tgz",
+          "integrity": "sha512-6JS+DXKyLgLPeLPnEXdN8vBjFME2P290/xvsQ5NDZq0WWCCzjaCgB1jq+ZnazVQPdtq7PBhldDN3j33QYMUOlg==",
           "requires": {
             "@babel/runtime": "^7.13.10",
             "@radix-ui/react-use-layout-effect": "0.1.1-rc.47"
           }
         },
-        "@radix-ui/react-popper": {
-          "version": "0.1.5-rc.47",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@floating-ui/react-dom": "0.7.2",
-            "@radix-ui/react-arrow": "0.1.5-rc.47",
-            "@radix-ui/react-compose-refs": "0.1.1-rc.47",
-            "@radix-ui/react-context": "0.1.2-rc.47",
-            "@radix-ui/react-primitive": "0.1.5-rc.47",
-            "@radix-ui/react-use-layout-effect": "0.1.1-rc.47",
-            "@radix-ui/react-use-rect": "0.1.2-rc.47",
-            "@radix-ui/react-use-size": "0.1.2-rc.47",
-            "@radix-ui/rect": "0.1.2-rc.7"
-          }
-        },
         "@radix-ui/react-portal": {
           "version": "0.1.5-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-0.1.5-rc.47.tgz",
+          "integrity": "sha512-vhCvW/V6xWsbA3/SQN4zzVFQtZpbZTDrq0p/KM+MhPx/jo46PLmtRLudT5h30AVzwTniLpjeMziy2Oy8aozFcQ==",
           "requires": {
             "@babel/runtime": "^7.13.10",
             "@radix-ui/react-primitive": "0.1.5-rc.47"
@@ -8336,6 +8591,8 @@
         },
         "@radix-ui/react-presence": {
           "version": "0.1.3-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-0.1.3-rc.47.tgz",
+          "integrity": "sha512-7Ey537IfQvXVBq66FyUEVfSPG5/4k46by/3VTmKgDYVD9MXG1TSyML7sJxaphydDAYTqCcPTFcWNTwbMDGiMvw==",
           "requires": {
             "@babel/runtime": "^7.13.10",
             "@radix-ui/react-compose-refs": "0.1.1-rc.47",
@@ -8344,6 +8601,8 @@
         },
         "@radix-ui/react-primitive": {
           "version": "0.1.5-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.5-rc.47.tgz",
+          "integrity": "sha512-eLpWe5H3YoLUjmAERxRQSBjWwu1yhhgljUcxdZMisGBEZNDrRF4Kg1oQvOGJTvQNQ/gUqD784MkbOP6woFcqzg==",
           "requires": {
             "@babel/runtime": "^7.13.10",
             "@radix-ui/react-slot": "0.1.3-rc.47"
@@ -8351,6 +8610,8 @@
         },
         "@radix-ui/react-slot": {
           "version": "0.1.3-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.3-rc.47.tgz",
+          "integrity": "sha512-nurUm75+/nb38nKpHjMqc4GNTDTbDu6KYDdZVJOm+sChaUDVFSdYTHC4A1c9R7k7vtrytFV/obTCc8pqEkU4Gg==",
           "requires": {
             "@babel/runtime": "^7.13.10",
             "@radix-ui/react-compose-refs": "0.1.1-rc.47"
@@ -8358,12 +8619,16 @@
         },
         "@radix-ui/react-use-callback-ref": {
           "version": "0.1.1-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.1-rc.47.tgz",
+          "integrity": "sha512-a/Q1GFXBDzgnRXI1/MV+P8CRXJZtManDS3zqq34avcLJB4adTVR4+mA3jPMEPsyKaqA08wzHtynSC2hgstRXsw==",
           "requires": {
             "@babel/runtime": "^7.13.10"
           }
         },
         "@radix-ui/react-use-controllable-state": {
           "version": "0.1.1-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.1.1-rc.47.tgz",
+          "integrity": "sha512-3MclvPRcCKFXDBxVAJdrkl7s3GKunav/fPE9plYwXy4Kg0cHT4EVAMfZZSG2MhqnBf5WpovYsX5Rtsrh7LwWRQ==",
           "requires": {
             "@babel/runtime": "^7.13.10",
             "@radix-ui/react-use-callback-ref": "0.1.1-rc.47"
@@ -8371,6 +8636,8 @@
         },
         "@radix-ui/react-use-escape-keydown": {
           "version": "0.1.1-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-0.1.1-rc.47.tgz",
+          "integrity": "sha512-a+/9xr5OgHfJCuGLwu8eoc6Vtee3ts5d9yX23sxUoj9q5utDJnodOslkzYmjheP2FOuI/IgrltjwPDdOZcqYPA==",
           "requires": {
             "@babel/runtime": "^7.13.10",
             "@radix-ui/react-use-callback-ref": "0.1.1-rc.47"
@@ -8378,32 +8645,16 @@
         },
         "@radix-ui/react-use-layout-effect": {
           "version": "0.1.1-rc.47",
-          "requires": {
-            "@babel/runtime": "^7.13.10"
-          }
-        },
-        "@radix-ui/react-use-rect": {
-          "version": "0.1.2-rc.47",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@radix-ui/rect": "0.1.2-rc.7"
-          }
-        },
-        "@radix-ui/react-use-size": {
-          "version": "0.1.2-rc.47",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@radix-ui/react-use-layout-effect": "0.1.1-rc.47"
-          }
-        },
-        "@radix-ui/rect": {
-          "version": "0.1.2-rc.7",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.1-rc.47.tgz",
+          "integrity": "sha512-ke77SzDqR+7qOXSL6wg95VxMRa3v+J//bnFZXdyA2Pc/J6EtwINoopOzDZvs2cp6yC3qRIWg5NWyGZVKUeQzSw==",
           "requires": {
             "@babel/runtime": "^7.13.10"
           }
         },
         "react-remove-scroll": {
           "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.4.tgz",
+          "integrity": "sha512-xGVKJJr0SJGQVirVFAUZ2k1QLyO6m+2fy0l8Qawbp5Jgrv3DeLalrfMNBFSlmz5kriGGzsVBtGVnf4pTKIhhWA==",
           "requires": {
             "react-remove-scroll-bar": "^2.3.3",
             "react-style-singleton": "^2.2.1",
@@ -8415,30 +8666,88 @@
       }
     },
     "@radix-ui/react-popper": {
-      "version": "1.1.0",
+      "version": "0.1.5-rc.47",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-0.1.5-rc.47.tgz",
+      "integrity": "sha512-HQc54eMp/GyPEbTZO5xBTM6CsquYDwtBFJcbw5sbx359jgEIG+OzBpiGtyzGmH7WJkrMnADizJC48LY3XMAlTA==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@floating-ui/react-dom": "0.7.2",
-        "@radix-ui/react-arrow": "1.0.1",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
-        "@radix-ui/react-use-callback-ref": "1.0.0",
-        "@radix-ui/react-use-layout-effect": "1.0.0",
-        "@radix-ui/react-use-rect": "1.0.0",
-        "@radix-ui/react-use-size": "1.0.0",
-        "@radix-ui/rect": "1.0.0"
+        "@radix-ui/react-arrow": "0.1.5-rc.47",
+        "@radix-ui/react-compose-refs": "0.1.1-rc.47",
+        "@radix-ui/react-context": "0.1.2-rc.47",
+        "@radix-ui/react-primitive": "0.1.5-rc.47",
+        "@radix-ui/react-use-layout-effect": "0.1.1-rc.47",
+        "@radix-ui/react-use-rect": "0.1.2-rc.47",
+        "@radix-ui/react-use-size": "0.1.2-rc.47",
+        "@radix-ui/rect": "0.1.2-rc.7"
+      },
+      "dependencies": {
+        "@radix-ui/react-compose-refs": {
+          "version": "0.1.1-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.1-rc.47.tgz",
+          "integrity": "sha512-FJRPt4lAfYEFVc5XfIa1ICprJNGjldbRN6v3NsQVZjNcStQcgFaNvvKzvaUyJS7SwNip0F5Inm7wX7aXOEjxiQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10"
+          }
+        },
+        "@radix-ui/react-context": {
+          "version": "0.1.2-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-0.1.2-rc.47.tgz",
+          "integrity": "sha512-0FphpYHmFDKXnxBGgshj0rxDTkws0OfxJ+9ozYtKLDXZ0XLfTt4iTdtjCz8bq7y/6NTa58xnydooGMvR0sVibw==",
+          "requires": {
+            "@babel/runtime": "^7.13.10"
+          }
+        },
+        "@radix-ui/react-primitive": {
+          "version": "0.1.5-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.5-rc.47.tgz",
+          "integrity": "sha512-eLpWe5H3YoLUjmAERxRQSBjWwu1yhhgljUcxdZMisGBEZNDrRF4Kg1oQvOGJTvQNQ/gUqD784MkbOP6woFcqzg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-slot": "0.1.3-rc.47"
+          }
+        },
+        "@radix-ui/react-slot": {
+          "version": "0.1.3-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.3-rc.47.tgz",
+          "integrity": "sha512-nurUm75+/nb38nKpHjMqc4GNTDTbDu6KYDdZVJOm+sChaUDVFSdYTHC4A1c9R7k7vtrytFV/obTCc8pqEkU4Gg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-compose-refs": "0.1.1-rc.47"
+          }
+        },
+        "@radix-ui/react-use-layout-effect": {
+          "version": "0.1.1-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.1-rc.47.tgz",
+          "integrity": "sha512-ke77SzDqR+7qOXSL6wg95VxMRa3v+J//bnFZXdyA2Pc/J6EtwINoopOzDZvs2cp6yC3qRIWg5NWyGZVKUeQzSw==",
+          "requires": {
+            "@babel/runtime": "^7.13.10"
+          }
+        },
+        "@radix-ui/react-use-size": {
+          "version": "0.1.2-rc.47",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-0.1.2-rc.47.tgz",
+          "integrity": "sha512-b9Czuxdf9mOM7k44l5agGC9XGXCri0DEzn4BUfoyQln/dRjZp67V7FkjT9rrDrRjxt1IL99V1INLtgfS0u8tUA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-use-layout-effect": "0.1.1-rc.47"
+          }
+        }
       }
     },
     "@radix-ui/react-portal": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.2.tgz",
+      "integrity": "sha512-swu32idoCW7KA2VEiUZGBSu9nB6qwGdV6k6HYhUoOo3M1FFpD+VgLzUqtt3mwL1ssz7r2x8MggpLSQach2Xy/Q==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-primitive": "1.0.1"
+        "@radix-ui/react-primitive": "1.0.2"
       }
     },
     "@radix-ui/react-presence": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
+      "integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "1.0.0",
@@ -8446,14 +8755,18 @@
       }
     },
     "@radix-ui/react-primitive": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.2.tgz",
+      "integrity": "sha512-zY6G5Qq4R8diFPNwtyoLRZBxzu1Z+SXMlfYpChN7Dv8gvmx9X3qhDqiLWvKseKVJMuedFeU/Sa0Sy/Ia+t06Dw==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-slot": "1.0.1"
       }
     },
     "@radix-ui/react-radio-group": {
-      "version": "1.1.1",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.1.2.tgz",
+      "integrity": "sha512-S7K8upMjOkx1fTUzEugbfCYPwI9Yw4m2h2ZfJP+ZWP/Mzc/LE2T6QgiAMaSaC3vZSxU5Kk5Eb377zMklWeaaCQ==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
@@ -8461,94 +8774,133 @@
         "@radix-ui/react-context": "1.0.0",
         "@radix-ui/react-direction": "1.0.0",
         "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
-        "@radix-ui/react-roving-focus": "1.0.2",
+        "@radix-ui/react-primitive": "1.0.2",
+        "@radix-ui/react-roving-focus": "1.0.3",
         "@radix-ui/react-use-controllable-state": "1.0.0",
         "@radix-ui/react-use-previous": "1.0.0",
         "@radix-ui/react-use-size": "1.0.0"
       }
     },
     "@radix-ui/react-roving-focus": {
-      "version": "1.0.2",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.3.tgz",
+      "integrity": "sha512-stjCkIoMe6h+1fWtXlA6cRfikdBzCLp3SnVk7c48cv/uy3DTGoXhN76YaOYUJuy3aEDvDIKwKR5KSmvrtPvQPQ==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-collection": "1.0.1",
+        "@radix-ui/react-collection": "1.0.2",
         "@radix-ui/react-compose-refs": "1.0.0",
         "@radix-ui/react-context": "1.0.0",
         "@radix-ui/react-direction": "1.0.0",
         "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-use-callback-ref": "1.0.0",
         "@radix-ui/react-use-controllable-state": "1.0.0"
       }
     },
-    "@radix-ui/react-scroll-area": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.0.2.tgz",
-      "integrity": "sha512-k8VseTxI26kcKJaX0HPwkvlNBPTs56JRdYzcZ/vzrNUkDlvXBy8sMc7WvCpYzZkHgb+hd72VW9MqkqecGtuNgg==",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/number": "1.0.0",
-        "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-direction": "1.0.0",
-        "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
-        "@radix-ui/react-use-callback-ref": "1.0.0",
-        "@radix-ui/react-use-layout-effect": "1.0.0"
-      }
-    },
     "@radix-ui/react-select": {
-      "version": "1.2.0",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-1.2.1.tgz",
+      "integrity": "sha512-GULRMITaOHNj79BZvQs3iZO0+f2IgI8g5HDhMi7Bnc13t7IlG86NFtOCfTLme4PNZdEtU+no+oGgcl6IFiphpQ==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/number": "1.0.0",
         "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-collection": "1.0.1",
+        "@radix-ui/react-collection": "1.0.2",
         "@radix-ui/react-compose-refs": "1.0.0",
         "@radix-ui/react-context": "1.0.0",
         "@radix-ui/react-direction": "1.0.0",
-        "@radix-ui/react-dismissable-layer": "1.0.2",
+        "@radix-ui/react-dismissable-layer": "1.0.3",
         "@radix-ui/react-focus-guards": "1.0.0",
-        "@radix-ui/react-focus-scope": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.2",
         "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-popper": "1.1.0",
-        "@radix-ui/react-portal": "1.0.1",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-popper": "1.1.1",
+        "@radix-ui/react-portal": "1.0.2",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-slot": "1.0.1",
         "@radix-ui/react-use-callback-ref": "1.0.0",
         "@radix-ui/react-use-controllable-state": "1.0.0",
         "@radix-ui/react-use-layout-effect": "1.0.0",
         "@radix-ui/react-use-previous": "1.0.0",
-        "@radix-ui/react-visually-hidden": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.2",
         "aria-hidden": "^1.1.1",
         "react-remove-scroll": "2.5.5"
+      },
+      "dependencies": {
+        "@radix-ui/react-arrow": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.0.2.tgz",
+          "integrity": "sha512-fqYwhhI9IarZ0ll2cUSfKuXHlJK0qE4AfnRrPBbRwEH/4mGQn04/QFGomLi8TXWIdv9WJk//KgGm+aDxVIr1wA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-primitive": "1.0.2"
+          }
+        },
+        "@radix-ui/react-popper": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.1.1.tgz",
+          "integrity": "sha512-keYDcdMPNMjSC8zTsZ8wezUMiWM9Yj14wtF3s0PTIs9srnEPC9Kt2Gny1T3T81mmSeyDjZxsD9N5WCwNNb712w==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@floating-ui/react-dom": "0.7.2",
+            "@radix-ui/react-arrow": "1.0.2",
+            "@radix-ui/react-compose-refs": "1.0.0",
+            "@radix-ui/react-context": "1.0.0",
+            "@radix-ui/react-primitive": "1.0.2",
+            "@radix-ui/react-use-callback-ref": "1.0.0",
+            "@radix-ui/react-use-layout-effect": "1.0.0",
+            "@radix-ui/react-use-rect": "1.0.0",
+            "@radix-ui/react-use-size": "1.0.0",
+            "@radix-ui/rect": "1.0.0"
+          }
+        },
+        "@radix-ui/react-use-rect": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.0.0.tgz",
+          "integrity": "sha512-TB7pID8NRMEHxb/qQJpvSt3hQU4sqNPM1VCTjTRjEOa7cEop/QMuq8S6fb/5Tsz64kqSvB9WnwsDHtjnrM9qew==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/rect": "1.0.0"
+          }
+        },
+        "@radix-ui/rect": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.0.0.tgz",
+          "integrity": "sha512-d0O68AYy/9oeEy1DdC07bz1/ZXX+DqCskRd3i4JzLSTXwefzaepQrKjXC7aNM8lTHjFLDO0pDgaEiQ7jEk+HVg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10"
+          }
+        }
       }
     },
     "@radix-ui/react-slot": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
+      "integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "1.0.0"
       }
     },
     "@radix-ui/react-switch": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.0.2.tgz",
+      "integrity": "sha512-BcG/LKehxt36NXG0wPnoCitIfSMtU9Xo7BmythYA1PAMLtsMvW7kALfBzmduQoHTWcKr0AVcFyh0gChBUp9TiQ==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
         "@radix-ui/react-compose-refs": "1.0.0",
         "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.2",
         "@radix-ui/react-use-controllable-state": "1.0.0",
         "@radix-ui/react-use-previous": "1.0.0",
         "@radix-ui/react-use-size": "1.0.0"
       }
     },
     "@radix-ui/react-tabs": {
-      "version": "1.0.2",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.3.tgz",
+      "integrity": "sha512-4CkF/Rx1GcrusI/JZ1Rvyx4okGUs6wEenWA0RG/N+CwkRhTy7t54y7BLsWUXrAz/GRbBfHQg/Odfs/RoW0CiRA==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.0",
@@ -8556,19 +8908,23 @@
         "@radix-ui/react-direction": "1.0.0",
         "@radix-ui/react-id": "1.0.0",
         "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
-        "@radix-ui/react-roving-focus": "1.0.2",
+        "@radix-ui/react-primitive": "1.0.2",
+        "@radix-ui/react-roving-focus": "1.0.3",
         "@radix-ui/react-use-controllable-state": "1.0.0"
       }
     },
     "@radix-ui/react-use-callback-ref": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
+      "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-use-controllable-state": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
+      "integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-callback-ref": "1.0.0"
@@ -8576,6 +8932,8 @@
     },
     "@radix-ui/react-use-escape-keydown": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.2.tgz",
+      "integrity": "sha512-DXGim3x74WgUv+iMNCF+cAo8xUHHeqvjx8zs7trKf+FkQKPQXLk2sX7Gx1ysH7Q76xCpZuxIJE7HLPxRE+Q+GA==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-callback-ref": "1.0.0"
@@ -8583,45 +8941,59 @@
     },
     "@radix-ui/react-use-layout-effect": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+      "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-use-previous": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.0.0.tgz",
+      "integrity": "sha512-RG2K8z/K7InnOKpq6YLDmT49HGjNmrK+fr82UCVKT2sW0GYfVnYp4wZWBooT/EYfQ5faA9uIjvsuMMhH61rheg==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-use-rect": {
-      "version": "1.0.0",
+      "version": "0.1.2-rc.47",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-0.1.2-rc.47.tgz",
+      "integrity": "sha512-u0PRRQQvnl9tld+7qAbWsrfN2rrtjyfXqK5+9BOooMWt9H6+OWDlau20iQzHdswuJfg8zeyO3u00k56r1tVSrw==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/rect": "1.0.0"
+        "@radix-ui/rect": "0.1.2-rc.7"
       }
     },
     "@radix-ui/react-use-size": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.0.0.tgz",
+      "integrity": "sha512-imZ3aYcoYCKhhgNpkNDh/aTiU05qw9hX+HHI1QDBTyIlcFjgeFlKKySNGMwTp7nYFLQg/j0VA2FmCY4WPDDHMg==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-layout-effect": "1.0.0"
       }
     },
     "@radix-ui/react-visually-hidden": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.2.tgz",
+      "integrity": "sha512-qirnJxtYn73HEk1rXL12/mXnu2rwsNHDID10th2JGtdK25T9wX+mxRmGt7iPSahw512GbZOc0syZX1nLQGoEOg==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-primitive": "1.0.1"
+        "@radix-ui/react-primitive": "1.0.2"
       }
     },
     "@radix-ui/rect": {
-      "version": "1.0.0",
+      "version": "0.1.2-rc.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-0.1.2-rc.7.tgz",
+      "integrity": "sha512-cfTp+HLF++BYp4RmwSUNCvjD+c6jahzVwkMUdFN6PLJSA/zLZR0OOXkvQhhNBOg9/XOxOLEJuYE8RJG5o2P1QA==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@react-leaflet/core": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
       "requires": {}
     },
     "@rushstack/eslint-patch": {
@@ -8646,8 +9018,23 @@
         "swiper": "^8.4.5"
       },
       "dependencies": {
+        "@iiif/vault-helpers": {
+          "version": "0.9.11",
+          "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.9.11.tgz",
+          "integrity": "sha512-4XuFPvu233mMzfU/mMpAqFY5aCTzwhJ0u7MzPcpN8nSfMwbV5Dyvv0PppjcocvbWMUUXScqerRoB1MAfSFas6w==",
+          "requires": {
+            "@iiif/presentation-2": "1.x",
+            "@iiif/presentation-3": "1.x",
+            "abs-svg-path": "^0.1.0",
+            "parse-svg-path": "^0.1.0",
+            "react-i18next": "^11.18.0",
+            "svg-arc-to-cubic-bezier": "^3.2.0"
+          }
+        },
         "@samvera/nectar-iiif": {
           "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.18.tgz",
+          "integrity": "sha512-o5gNHdhoG12bNC56lAgT050SKKnDWYTNwaJJGD9qnS48gmVR+FGsTSrLub9boesU0uo6wanMJBsMBSPgt4IlvA==",
           "requires": {
             "@stitches/react": "^1.2.7",
             "hls.js": "^1.1.5",
@@ -8655,15 +9042,25 @@
             "react-dom": "^16.8  || ^17.0 || ^18.0",
             "sanitize-html": "^2.7.0"
           }
+        },
+        "swiper": {
+          "version": "8.4.7",
+          "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.7.tgz",
+          "integrity": "sha512-VwO/KU3i9IV2Sf+W2NqyzwWob4yX9Qdedq6vBtS0rFqJ6Fa5iLUJwxQkuD4I38w0WDJwmFl8ojkdcRFPHWD+2g==",
+          "requires": {
+            "dom7": "^4.0.4",
+            "ssr-window": "^4.0.2"
+          }
         }
       }
     },
     "@samvera/clover-iiif": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.13.2.tgz",
-      "integrity": "sha512-KVQBRZfMGw4VsLp8GLPZoNYboY6164G22cdsn/i3byNU6qiPYm9tuUKg9AquQwCxXWSJf2k53l9Roqy9QjRn6A==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.14.1.tgz",
+      "integrity": "sha512-5VcR/UnWn17PJVDmmS0VzNf0POYqfhoW88LZ2WH8CZUhVSihNnqBcUO2qhPPxhGcAKnOGYy2TPTQit7vMSHILg==",
       "requires": {
         "@iiif/vault": "^0.9.19",
+        "@iiif/vault-helpers": "^0.9.11",
         "@nulib/design-system": "^1.6.0",
         "@radix-ui/react-collapsible": "^1.0.1",
         "@radix-ui/react-radio-group": "^1.1.0",
@@ -8681,8 +9078,23 @@
         "uuid": "^9.0.0"
       },
       "dependencies": {
+        "@iiif/vault-helpers": {
+          "version": "0.9.11",
+          "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.9.11.tgz",
+          "integrity": "sha512-4XuFPvu233mMzfU/mMpAqFY5aCTzwhJ0u7MzPcpN8nSfMwbV5Dyvv0PppjcocvbWMUUXScqerRoB1MAfSFas6w==",
+          "requires": {
+            "@iiif/presentation-2": "1.x",
+            "@iiif/presentation-3": "1.x",
+            "abs-svg-path": "^0.1.0",
+            "parse-svg-path": "^0.1.0",
+            "react-i18next": "^11.18.0",
+            "svg-arc-to-cubic-bezier": "^3.2.0"
+          }
+        },
         "@samvera/nectar-iiif": {
           "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.18.tgz",
+          "integrity": "sha512-o5gNHdhoG12bNC56lAgT050SKKnDWYTNwaJJGD9qnS48gmVR+FGsTSrLub9boesU0uo6wanMJBsMBSPgt4IlvA==",
           "requires": {
             "@stitches/react": "^1.2.7",
             "hls.js": "^1.1.5",
@@ -8707,10 +9119,14 @@
     },
     "@stitches/react": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@stitches/react/-/react-1.2.8.tgz",
+      "integrity": "sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==",
       "requires": {}
     },
     "@swc/helpers": {
       "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
       "requires": {
         "tslib": "^2.4.0"
       }
@@ -8732,9 +9148,9 @@
       }
     },
     "@types/eslint": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.1.tgz",
-      "integrity": "sha512-rc9K8ZpVjNcLs8Fp0dkozd5Pt2Apk1glO4Vgz8ix1u6yFByxfqo5Yavpy65o+93TAe24jr7v+eSBtFLvOQtCRQ==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.3.tgz",
+      "integrity": "sha512-fa7GkppZVEByMWGbTtE5MbmXWJTVbrjjaS8K6uQj+XtuuUv1fsuPAxhygfqLmsb/Ufb3CV8deFCpiMfAgi00Sw==",
       "peer": true,
       "requires": {
         "@types/estree": "*",
@@ -8765,7 +9181,9 @@
       }
     },
     "@types/geojson": {
-      "version": "7946.0.10"
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
     },
     "@types/hast": {
       "version": "2.3.4",
@@ -8787,30 +9205,32 @@
       "dev": true
     },
     "@types/leaflet": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.0.tgz",
-      "integrity": "sha512-7LeOSj7EloC5UcyOMo+1kc3S1UT3MjJxwqsMT1d2PTyvQz53w0Y0oSSk9nwZnOZubCmBvpSNGceucxiq+ZPEUw==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.3.tgz",
+      "integrity": "sha512-Caa1lYOgKVqDkDZVWkto2Z5JtVo09spEaUt2S69LiugbBpoqQu92HYFMGUbYezZbnBkyOxMNPXHSgRrRY5UyIA==",
       "dev": true,
       "requires": {
         "@types/geojson": "*"
       }
     },
     "@types/lodash": {
-      "version": "4.14.191",
+      "version": "4.14.192",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.192.tgz",
+      "integrity": "sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A==",
       "dev": true
     },
     "@types/mdast": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
-      "integrity": "sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz",
+      "integrity": "sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==",
       "requires": {
         "@types/unist": "*"
       }
     },
     "@types/mdx": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.3.tgz",
-      "integrity": "sha512-IgHxcT3RC8LzFLhKwP3gbMPeaK7BM9eBH46OdapPA7yvuIUJ8H6zHZV53J8hGZcTSnt95jANt+rTBNUUc22ACQ=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.4.tgz",
+      "integrity": "sha512-qCYrNdpKwN6YO6FVnx+ulfqifKlE3lQGsNhvDaW9Oxzyob/cRLBJWow8GHBBD4NxQ7BVvtsATgLsX0vZAWmtrg=="
     },
     "@types/ms": {
       "version": "0.7.31",
@@ -8818,14 +9238,20 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
-      "version": "18.11.18"
+      "version": "18.15.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q=="
     },
     "@types/prop-types": {
       "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
       "devOptional": true
     },
     "@types/react": {
-      "version": "18.0.27",
+      "version": "18.0.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.31.tgz",
+      "integrity": "sha512-EEG67of7DsvRDU6BLLI0p+k1GojDLz9+lZsnCpCRTa/lOokvyPBvp8S5x+A24hME3yyQuIipcP70KJ6H7Qupww==",
       "devOptional": true,
       "requires": {
         "@types/prop-types": "*",
@@ -8834,14 +9260,18 @@
       }
     },
     "@types/react-dom": {
-      "version": "18.0.10",
+      "version": "18.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
+      "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
       "dev": true,
       "requires": {
         "@types/react": "*"
       }
     },
     "@types/scheduler": {
-      "version": "0.16.2",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
       "devOptional": true
     },
     "@types/semver": {
@@ -8856,71 +9286,71 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.52.0.tgz",
-      "integrity": "sha512-lHazYdvYVsBokwCdKOppvYJKaJ4S41CgKBcPvyd0xjZNbvQdhn/pnJlGtQksQ/NhInzdaeaSarlBjDXHuclEbg==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.0.tgz",
+      "integrity": "sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.52.0",
-        "@typescript-eslint/type-utils": "5.52.0",
-        "@typescript-eslint/utils": "5.52.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/type-utils": "5.57.0",
+        "@typescript-eslint/utils": "5.57.0",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
-        "regexpp": "^3.2.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.52.0.tgz",
-      "integrity": "sha512-e2KiLQOZRo4Y0D/b+3y08i3jsekoSkOYStROYmPUnGMEoA0h+k2qOH5H6tcjIc68WDvGwH+PaOrP1XRzLJ6QlA==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.0.tgz",
+      "integrity": "sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.52.0",
-        "@typescript-eslint/types": "5.52.0",
-        "@typescript-eslint/typescript-estree": "5.52.0",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.52.0.tgz",
-      "integrity": "sha512-AR7sxxfBKiNV0FWBSARxM8DmNxrwgnYMPwmpkC1Pl1n+eT8/I2NAUPuwDy/FmDcC6F8pBfmOcaxcxRHspgOBMw==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.0.tgz",
+      "integrity": "sha512-NANBNOQvllPlizl9LatX8+MHi7bx7WGIWYjPHDmQe5Si/0YEYfxSljJpoTyTWFTgRy3X8gLYSE4xQ2U+aCozSw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.52.0",
-        "@typescript-eslint/visitor-keys": "5.52.0"
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/visitor-keys": "5.57.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.52.0.tgz",
-      "integrity": "sha512-tEKuUHfDOv852QGlpPtB3lHOoig5pyFQN/cUiZtpw99D93nEBjexRLre5sQZlkMoHry/lZr8qDAt2oAHLKA6Jw==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.57.0.tgz",
+      "integrity": "sha512-kxXoq9zOTbvqzLbdNKy1yFrxLC6GDJFE2Yuo3KqSwTmDOFjUGeWSakgoXT864WcK5/NAJkkONCiKb1ddsqhLXQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.52.0",
-        "@typescript-eslint/utils": "5.52.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
+        "@typescript-eslint/utils": "5.57.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.52.0.tgz",
-      "integrity": "sha512-oV7XU4CHYfBhk78fS7tkum+/Dpgsfi91IIDy7fjCyq2k6KB63M6gMC0YIvy+iABzmXThCRI6xpCEyVObBdWSDQ==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.0.tgz",
+      "integrity": "sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.52.0.tgz",
-      "integrity": "sha512-WeWnjanyEwt6+fVrSR0MYgEpUAuROxuAH516WPjUblIrClzYJj0kBbjdnbQXLpgAN8qbEuGywiQsXUVDiAoEuQ==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.0.tgz",
+      "integrity": "sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.52.0",
-        "@typescript-eslint/visitor-keys": "5.52.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/visitor-keys": "5.57.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -8929,28 +9359,28 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.52.0.tgz",
-      "integrity": "sha512-As3lChhrbwWQLNk2HC8Ree96hldKIqk98EYvypd3It8Q1f8d5zWyIoaZEp2va5667M4ZyE7X8UUR+azXrFl+NA==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.57.0.tgz",
+      "integrity": "sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==",
       "dev": true,
       "requires": {
+        "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.52.0",
-        "@typescript-eslint/types": "5.52.0",
-        "@typescript-eslint/typescript-estree": "5.52.0",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.52.0.tgz",
-      "integrity": "sha512-qMwpw6SU5VHCPr99y274xhbm+PRViK/NATY6qzt+Et7+mThGuFSl/ompj2/hrBlRP/kq+BFdgagnOSgw9TB0eA==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.0.tgz",
+      "integrity": "sha512-ery2g3k0hv5BLiKpPuwYt9KBkAp2ugT6VvyShXdLOkax895EC55sP0Tx5L0fZaQueiK3fBLvHVvEl3jFS5ia+g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.52.0",
+        "@typescript-eslint/types": "5.57.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -9114,6 +9544,8 @@
     },
     "abs-svg-path": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
       "optional": true
     },
     "acorn": {
@@ -9174,7 +9606,9 @@
       "dev": true
     },
     "aria-hidden": {
-      "version": "1.2.2",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
+      "integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
       "requires": {
         "tslib": "^2.0.0"
       }
@@ -9186,6 +9620,16 @@
       "dev": true,
       "requires": {
         "deep-equal": "^2.0.5"
+      }
+    },
+    "array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
       }
     },
     "array-includes": {
@@ -9269,6 +9713,8 @@
     },
     "axios": {
       "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "requires": {
         "follow-redirects": "^1.14.4"
       }
@@ -9347,7 +9793,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001449"
+      "version": "1.0.30001472",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001472.tgz",
+      "integrity": "sha512-xWC/0+hHHQgj3/vrKYY0AAzeIUgr7L9wlELIcAvZdDUHlhL/kNxMdnQLOSOQfP8R51ZzPhmHdyMkI0MMpmxCfg=="
     },
     "ccount": {
       "version": "2.0.1",
@@ -9386,6 +9834,8 @@
     },
     "charm": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/charm/-/charm-1.0.2.tgz",
+      "integrity": "sha512-wqW3VdPnlSWT4eRiYX+hcs+C6ViBPUWk1qTCd+37qw9kEm/a5n2qcyQDMBWvSYKN/ctqZzeXNQaeBjOetJJUkw==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1"
@@ -9398,10 +9848,14 @@
       "peer": true
     },
     "client-only": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "clsx": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
     },
     "color-convert": {
       "version": "2.0.1",
@@ -9424,7 +9878,9 @@
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
     },
     "commander": {
-      "version": "7.2.0"
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -9453,6 +9909,8 @@
     },
     "csstype": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
       "devOptional": true
     },
     "damerau-levenshtein": {
@@ -9462,7 +9920,9 @@
       "dev": true
     },
     "data-uri-to-buffer": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
     },
     "debug": {
       "version": "4.3.4",
@@ -9512,7 +9972,9 @@
       "dev": true
     },
     "deepmerge": {
-      "version": "4.2.2"
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
     },
     "define-lazy-prop": {
       "version": "2.0.0",
@@ -9536,7 +9998,9 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
     "detect-node-es": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "diff": {
       "version": "5.1.0",
@@ -9563,6 +10027,8 @@
     },
     "dom-serializer": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "requires": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -9570,22 +10036,30 @@
       }
     },
     "dom7": {
-      "version": "4.0.4",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.6.tgz",
+      "integrity": "sha512-emjdpPLhpNubapLFdjNL9tP06Sr+GZkrIHEXLWvOGsytACUrkbeIdjO5g77m00BrHTznnlcNqgmn7pCN192TBA==",
       "requires": {
         "ssr-window": "^4.0.0"
       }
     },
     "domelementtype": {
-      "version": "2.3.0"
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
     },
     "domhandler": {
       "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "requires": {
         "domelementtype": "^2.3.0"
       }
     },
     "domutils": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
       "requires": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -9593,9 +10067,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.316",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.316.tgz",
-      "integrity": "sha512-9urqVpdeJYAwVL/sBjsX2pSlgYI/b4nOqC6UaNa0xlq1VUbXLRhERWlxcQ4FWfUOQQxSSxN/taFtapEcwg5tVA==",
+      "version": "1.4.342",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.342.tgz",
+      "integrity": "sha512-dTei3VResi5bINDENswBxhL+N0Mw5YnfWyTqO75KGsVldurEkhC9+CelJVAse8jycWyP8pv3VSj4BSyP8wTWJA==",
       "peer": true
     },
     "emoji-regex": {
@@ -9614,21 +10088,23 @@
       }
     },
     "entities": {
-      "version": "4.4.0"
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
     },
     "es-abstract": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
-      "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+      "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
       "dev": true,
       "requires": {
+        "array-buffer-byte-length": "^1.0.0",
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "get-symbol-description": "^1.0.0",
         "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
@@ -9636,8 +10112,8 @@
         "has-property-descriptors": "^1.0.0",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.4",
-        "is-array-buffer": "^3.0.1",
+        "internal-slot": "^1.0.5",
+        "is-array-buffer": "^3.0.2",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
@@ -9645,11 +10121,12 @@
         "is-string": "^1.0.7",
         "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.2",
+        "object-inspect": "^1.12.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
         "safe-regex-test": "^1.0.0",
+        "string.prototype.trim": "^1.2.7",
         "string.prototype.trimend": "^1.0.6",
         "string.prototype.trimstart": "^1.0.6",
         "typed-array-length": "^1.0.4",
@@ -9718,15 +10195,20 @@
       "peer": true
     },
     "escape-string-regexp": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
     },
     "eslint": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.34.0.tgz",
-      "integrity": "sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==",
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.37.0.tgz",
+      "integrity": "sha512-NU3Ps9nI05GUoVMxcZx1J8CNR6xOvUT4jAUMH5+z8lpp3aEdPVCImKw6PWG4PY+Vfkpr+jvMpxs/qoE7wq0sPw==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.4.1",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.0.2",
+        "@eslint/js": "8.37.0",
         "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -9737,10 +10219,9 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.4.0",
-        "esquery": "^1.4.0",
+        "eslint-visitor-keys": "^3.4.0",
+        "espree": "^9.5.1",
+        "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
@@ -9761,7 +10242,6 @@
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
@@ -9776,22 +10256,16 @@
             "esrecurse": "^4.3.0",
             "estraverse": "^5.2.0"
           }
-        },
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
         }
       }
     },
     "eslint-config-next": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.1.6.tgz",
-      "integrity": "sha512-0cg7h5wztg/SoLAlxljZ0ZPUQ7i6QKqRiP4M2+MgTZtxWwNKb2JSwNc18nJ6/kXBI6xYvPraTbQSIhAuVw6czw==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.2.4.tgz",
+      "integrity": "sha512-lunIBhsoeqw6/Lfkd6zPt25w1bn0znLA/JCL+au1HoEpSb4/PpsOYsYtgV/q+YPsoKIOzFyU5xnb04iZnXjUvg==",
       "dev": true,
       "requires": {
-        "@next/eslint-plugin-next": "13.1.6",
+        "@next/eslint-plugin-next": "13.2.4",
         "@rushstack/eslint-patch": "^1.1.3",
         "@typescript-eslint/parser": "^5.42.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -9803,9 +10277,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
-      "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
       "dev": true,
       "requires": {}
     },
@@ -10000,12 +10474,6 @@
             "esutils": "^2.0.2"
           }
         },
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        },
         "resolve": {
           "version": "2.0.0-next.4",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
@@ -10048,57 +10516,39 @@
       "requires": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
-      }
-    },
-    "eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "requires": {
-        "eslint-visitor-keys": "^2.0.0"
       },
       "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-          "dev": true
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
         }
       }
     },
     "eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
       "dev": true
     },
     "espree": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
+      "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.0"
       }
     },
     "esquery": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
-      "integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        }
       }
     },
     "esrecurse": {
@@ -10107,19 +10557,12 @@
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "requires": {
         "estraverse": "^5.2.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
-        }
       }
     },
     "estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
     },
     "estree-util-attach-comments": {
       "version": "2.1.1",
@@ -10239,6 +10682,8 @@
     },
     "fetch-blob": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
       "requires": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -10294,7 +10739,9 @@
       "integrity": "sha512-XGozTsMPYkm+6b5QL3Z9wQcJjNYxp0CYn3U1gO7dwD6PAqU1SVWZxI9CCg3z+ml3YfqdPnrBehaBrnH2AGKbNA=="
     },
     "follow-redirects": {
-      "version": "1.15.2"
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -10307,16 +10754,18 @@
     },
     "formdata-polyfill": {
       "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "requires": {
         "fetch-blob": "^3.1.2"
       }
     },
     "framer-motion": {
-      "version": "8.5.4",
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.9.4.tgz",
+      "integrity": "sha512-x3tYEKI+pTG43LdXjJe4Cu2VjTwW+XkQ0Uc3ByNbze5kny8Y/x0Bq+18wsBwKgCRBFZxltUeOpBBjLz0tg8lEA==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.2",
-        "@motionone/dom": "^10.15.3",
-        "hey-listen": "^1.0.8",
         "tslib": "^2.4.0"
       }
     },
@@ -10362,7 +10811,9 @@
       }
     },
     "get-nonce": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
     },
     "get-symbol-description": {
       "version": "1.0.0",
@@ -10375,21 +10826,21 @@
       }
     },
     "get-tsconfig": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.4.0.tgz",
-      "integrity": "sha512-0Gdjo/9+FzsYhXCEFueo2aY1z1tpXrxWZzP7k8ul9qt1U5o8rYJwTJYmaeHdrVosYIVYkOy2iwCJ9FdpocJhPQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.5.0.tgz",
+      "integrity": "sha512-MjhiaIWCJ1sAU4pIQ5i5OfOuHHxVo1oYeNsWTON7jxYkod8pHocXeh+SSbmu5OZZZK73B6cbJ2XADzXehLyovQ==",
       "dev": true
     },
     "glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
+        "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -10463,9 +10914,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -10550,30 +11001,35 @@
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
       "integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng=="
     },
-    "hey-listen": {
-      "version": "1.0.8"
-    },
     "hls.js": {
-      "version": "1.3.1"
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.3.5.tgz",
+      "integrity": "sha512-uybAvKS6uDe0MnWNEPnO0krWVr+8m2R0hJ/viql8H3MVK+itq8gGQuIYoFHL3rECkIpNH98Lw8YuuWMKZxp3Ew=="
     },
     "html-parse-stringify": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
       "optional": true,
       "requires": {
         "void-elements": "3.1.0"
       }
     },
     "htmlparser2": {
-      "version": "8.0.1",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
       "requires": {
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
+        "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
-        "entities": "^4.3.0"
+        "entities": "^4.4.0"
       }
     },
     "i18next": {
-      "version": "22.4.9",
+      "version": "22.4.13",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.4.13.tgz",
+      "integrity": "sha512-GX7flMHRRqQA0I1yGLmaZ4Hwt1JfLqagk8QPDPZsqekbKtXsuIngSVWM/s3SLgNkrEXjA+0sMGNuOEkkmyqmWg==",
       "optional": true,
       "peer": true,
       "requires": {
@@ -10614,6 +11070,8 @@
     },
     "inherits": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "inline-style-parser": {
@@ -10634,6 +11092,8 @@
     },
     "invariant": {
       "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -10663,13 +11123,13 @@
       }
     },
     "is-array-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
-      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "is-typed-array": "^1.1.10"
       }
     },
@@ -10791,7 +11251,9 @@
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
     },
     "is-plain-object": {
-      "version": "5.0.0"
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "is-reference": {
       "version": "3.0.1",
@@ -10926,13 +11388,15 @@
       }
     },
     "js-sdsl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
-      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
+      "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
       "dev": true
     },
     "js-tokens": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -11000,7 +11464,9 @@
       }
     },
     "leaflet": {
-      "version": "1.9.3"
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.3.tgz",
+      "integrity": "sha512-iB2cR9vAkDOu5l3HAay2obcUHZ7xwUBBjph8+PGtmW/2lYhbLizWtG7nTeYht36WfOslixQF9D/uSIzhZgGMfQ=="
     },
     "levn": {
       "version": "0.4.1",
@@ -11028,7 +11494,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -11043,6 +11511,8 @@
     },
     "loose-envify": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -11554,7 +12024,9 @@
       "dev": true
     },
     "mitt": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
     },
     "mri": {
       "version": "1.2.0",
@@ -11567,7 +12039,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nanoid": {
-      "version": "3.3.4"
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -11588,22 +12062,24 @@
       "peer": true
     },
     "next": {
-      "version": "13.1.5",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.2.4.tgz",
+      "integrity": "sha512-g1I30317cThkEpvzfXujf0O4wtaQHtDCLhlivwlTJ885Ld+eOgcz7r3TGQzeU+cSRoNHtD8tsJgzxVdYojFssw==",
       "requires": {
-        "@next/env": "13.1.5",
-        "@next/swc-android-arm-eabi": "13.1.5",
-        "@next/swc-android-arm64": "13.1.5",
-        "@next/swc-darwin-arm64": "13.1.5",
-        "@next/swc-darwin-x64": "13.1.5",
-        "@next/swc-freebsd-x64": "13.1.5",
-        "@next/swc-linux-arm-gnueabihf": "13.1.5",
-        "@next/swc-linux-arm64-gnu": "13.1.5",
-        "@next/swc-linux-arm64-musl": "13.1.5",
-        "@next/swc-linux-x64-gnu": "13.1.5",
-        "@next/swc-linux-x64-musl": "13.1.5",
-        "@next/swc-win32-arm64-msvc": "13.1.5",
-        "@next/swc-win32-ia32-msvc": "13.1.5",
-        "@next/swc-win32-x64-msvc": "13.1.5",
+        "@next/env": "13.2.4",
+        "@next/swc-android-arm-eabi": "13.2.4",
+        "@next/swc-android-arm64": "13.2.4",
+        "@next/swc-darwin-arm64": "13.2.4",
+        "@next/swc-darwin-x64": "13.2.4",
+        "@next/swc-freebsd-x64": "13.2.4",
+        "@next/swc-linux-arm-gnueabihf": "13.2.4",
+        "@next/swc-linux-arm64-gnu": "13.2.4",
+        "@next/swc-linux-arm64-musl": "13.2.4",
+        "@next/swc-linux-x64-gnu": "13.2.4",
+        "@next/swc-linux-x64-musl": "13.2.4",
+        "@next/swc-win32-arm64-msvc": "13.2.4",
+        "@next/swc-win32-ia32-msvc": "13.2.4",
+        "@next/swc-win32-x64-msvc": "13.2.4",
         "@swc/helpers": "0.4.14",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
@@ -11611,17 +12087,25 @@
       }
     },
     "next-absolute-url": {
-      "version": "1.2.2"
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/next-absolute-url/-/next-absolute-url-1.2.2.tgz",
+      "integrity": "sha512-Z2+LZXQTthhw2je9u4eq8QWXxXd57a6b54x9exBfQX4Dct6YxaMjcXZWNLHd9AOlCue84EsMpdSGP7wACqUnPg=="
     },
     "next-themes": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
+      "integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
       "requires": {}
     },
     "node-domexception": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
-      "version": "3.3.0",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
       "requires": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -11636,6 +12120,8 @@
     },
     "node-webvtt": {
       "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/node-webvtt/-/node-webvtt-1.9.4.tgz",
+      "integrity": "sha512-EjrJdKdxSyd8j4LMLW6s2Ah4yNoeVXp18Ob04CQl1In18xcUmKzEE8pcsxxnFVqanTyjbGYph2VnvtwIXR4EjA==",
       "requires": {
         "commander": "^7.1.0"
       }
@@ -11733,9 +12219,9 @@
       }
     },
     "open": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.1.tgz",
-      "integrity": "sha512-/4b7qZNhv6Uhd7jjnREh1NjnPxlTq+XNWPG88Ydkj5AILcA5m3ajvcg57pB24EQjKv0dK62XnDqk9c/hkIG5Kg==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "requires": {
         "define-lazy-prop": "^2.0.0",
@@ -11744,7 +12230,9 @@
       }
     },
     "openseadragon": {
-      "version": "2.4.2"
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/openseadragon/-/openseadragon-2.4.2.tgz",
+      "integrity": "sha512-398KbZwRtOYA6OmeWRY4Q0737NTacQ9Q6whmr9Lp1MNQO3p0eBz5LIASRne+4gwequcSM1vcHcjfy3dIndQziw=="
     },
     "optionator": {
       "version": "0.9.1",
@@ -11803,10 +12291,14 @@
       }
     },
     "parse-srcset": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
     },
     "parse-svg-path": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
       "optional": true
     },
     "path-exists": {
@@ -11850,7 +12342,9 @@
       }
     },
     "picocolors": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -11860,6 +12354,8 @@
     },
     "postcss": {
       "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -11916,12 +12412,16 @@
     },
     "react": {
       "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "requires": {
         "loose-envify": "^1.1.0"
       }
     },
     "react-dom": {
       "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -11929,12 +12429,16 @@
     },
     "react-error-boundary": {
       "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
       "requires": {
         "@babel/runtime": "^7.12.5"
       }
     },
     "react-i18next": {
       "version": "11.18.6",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
+      "integrity": "sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==",
       "optional": true,
       "requires": {
         "@babel/runtime": "^7.14.5",
@@ -11942,7 +12446,9 @@
       }
     },
     "react-intersection-observer": {
-      "version": "9.4.1",
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.4.3.tgz",
+      "integrity": "sha512-WNRqMQvKpupr6MzecAQI0Pj0+JQong307knLP4g/nBex7kYfIaZsPpXaIhKHR+oV8z+goUbH9e10j6lGRnTzlQ==",
       "requires": {}
     },
     "react-is": {
@@ -11952,17 +12458,23 @@
       "dev": true
     },
     "react-leaflet": {
-      "version": "4.2.0",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
       "requires": {
         "@react-leaflet/core": "^2.1.0"
       }
     },
     "react-masonry-css": {
       "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/react-masonry-css/-/react-masonry-css-1.0.16.tgz",
+      "integrity": "sha512-KSW0hR2VQmltt/qAa3eXOctQDyOu7+ZBevtKgpNDSzT7k5LA/0XntNa9z9HKCdz3QlxmJHglTZ18e4sX4V8zZQ==",
       "requires": {}
     },
     "react-remove-scroll": {
       "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+      "integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
       "requires": {
         "react-remove-scroll-bar": "^2.3.3",
         "react-style-singleton": "^2.2.1",
@@ -11973,6 +12485,8 @@
     },
     "react-remove-scroll-bar": {
       "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+      "integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
       "requires": {
         "react-style-singleton": "^2.2.1",
         "tslib": "^2.0.0"
@@ -11980,6 +12494,8 @@
     },
     "react-style-singleton": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
       "requires": {
         "get-nonce": "^1.0.0",
         "invariant": "^2.2.4",
@@ -11987,13 +12503,17 @@
       }
     },
     "redux": {
-      "version": "4.2.0",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.11"
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",
@@ -12005,12 +12525,6 @@
         "define-properties": "^1.1.3",
         "functions-have-names": "^1.2.2"
       }
-    },
-    "regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true
     },
     "remark-mdx": {
       "version": "2.3.0",
@@ -12109,7 +12623,9 @@
       }
     },
     "sanitize-html": {
-      "version": "2.8.1",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.10.0.tgz",
+      "integrity": "sha512-JqdovUd81dG4k87vZt6uA6YhDfWkUGruUu/aPmXLxXi45gZExnt9Bnw/qeQU8oGf82vPyaE0vO4aH0PbobB9JQ==",
       "requires": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
@@ -12121,6 +12637,8 @@
     },
     "scheduler": {
       "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -12187,7 +12705,9 @@
       "dev": true
     },
     "slugify": {
-      "version": "1.6.5"
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw=="
     },
     "source-map": {
       "version": "0.7.4",
@@ -12195,7 +12715,9 @@
       "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
     },
     "source-map-js": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
     "source-map-support": {
       "version": "0.5.21",
@@ -12221,7 +12743,9 @@
       "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
     },
     "ssr-window": {
-      "version": "4.0.2"
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
     },
     "stop-iteration-iterator": {
       "version": "1.0.0",
@@ -12246,6 +12770,17 @@
         "internal-slot": "^1.0.3",
         "regexp.prototype.flags": "^1.4.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       }
     },
     "string.prototype.trimend": {
@@ -12310,6 +12845,8 @@
     },
     "styled-jsx": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
       "requires": {
         "client-only": "0.0.1"
       }
@@ -12331,12 +12868,15 @@
     },
     "svg-arc-to-cubic-bezier": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
       "optional": true
     },
     "swiper": {
-      "version": "8.4.6",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-9.1.1.tgz",
+      "integrity": "sha512-D1zArOwI6XCXCYBULPA4jTxpqp5SQtvntjinbXNZwXzj6P3KS51zSWuMarCLXq5oRISay4nX+TuShpxz8qhtbw==",
       "requires": {
-        "dom7": "^4.0.4",
         "ssr-window": "^4.0.2"
       }
     },
@@ -12356,9 +12896,9 @@
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
     },
     "terser": {
-      "version": "5.16.5",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.5.tgz",
-      "integrity": "sha512-qcwfg4+RZa3YvlFh0qjifnzBHjKGNbtDo9yivMqMFDy9Q6FSaQWSB/j1xKhsoUFJIqDOM3TsN6D5xbrMrFcHbg==",
+      "version": "5.16.8",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.8.tgz",
+      "integrity": "sha512-QI5g1E/ef7d+PsDifb+a6nnVgC4F22Bg6T0xrBrz6iloVB4PUkkunp6V8nzoOOZJIzjWVdAGqCdlKlhLq/TbIA==",
       "peer": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
@@ -12376,16 +12916,16 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
-      "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz",
+      "integrity": "sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==",
       "peer": true,
       "requires": {
-        "@jridgewell/trace-mapping": "^0.3.14",
+        "@jridgewell/trace-mapping": "^0.3.17",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.0",
-        "terser": "^5.14.1"
+        "serialize-javascript": "^6.0.1",
+        "terser": "^5.16.5"
       }
     },
     "text-table": {
@@ -12405,7 +12945,9 @@
       }
     },
     "tiny-invariant": {
-      "version": "1.3.1"
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -12432,19 +12974,21 @@
       "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
     },
     "tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
+      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
       "dev": true,
       "requires": {
         "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
+        "json5": "^1.0.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
     },
     "tslib": {
-      "version": "2.5.0"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -12490,10 +13034,14 @@
       }
     },
     "typesafe-actions": {
-      "version": "5.1.0"
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/typesafe-actions/-/typesafe-actions-5.1.0.tgz",
+      "integrity": "sha512-bna6Yi1pRznoo6Bz1cE6btB/Yy8Xywytyfrzu/wc+NFW3ZF0I+2iCGImhBsoYYCOWuICtRO4yHcnDlzgo1AdNg=="
     },
     "typescript": {
-      "version": "4.9.4",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
       "dev": true
     },
     "unbox-primitive": {
@@ -12607,23 +13155,31 @@
     },
     "use-callback-ref": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
       "requires": {
         "tslib": "^2.0.0"
       }
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
       "requires": {}
     },
     "use-sidecar": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
       "requires": {
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"
       }
     },
     "uuid": {
-      "version": "9.0.0"
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "uvu": {
       "version": "0.5.6",
@@ -12667,6 +13223,8 @@
     },
     "void-elements": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
       "optional": true
     },
     "watchpack": {
@@ -12680,12 +13238,14 @@
       }
     },
     "web-streams-polyfill": {
-      "version": "3.2.1"
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+      "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
       "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,6 @@
       "name": "canopy-iiif",
       "dependencies": {
         "@iiif/parser": "^1.1.2",
-        "@iiif/vault": "^0.9.22",
-        "@iiif/vault-helpers": "^0.10.0",
         "@mdx-js/loader": "^2.3.0",
         "@next/mdx": "^13.2.3",
         "@radix-ui/colors": "^0.1.8",
@@ -248,9 +246,9 @@
       }
     },
     "node_modules/@iiif/vault-helpers": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.10.0.tgz",
-      "integrity": "sha512-gnjTPcZJMIDjwU5K8HYNU8Iix49Awmsr7IhIyxA5ZCqugnLjHvJUOmOvT7q1NRd6ia4+09wxx+EMH0D9mt4cxQ==",
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.9.11.tgz",
+      "integrity": "sha512-4XuFPvu233mMzfU/mMpAqFY5aCTzwhJ0u7MzPcpN8nSfMwbV5Dyvv0PppjcocvbWMUUXScqerRoB1MAfSFas6w==",
       "dependencies": {
         "@iiif/presentation-2": "1.x",
         "@iiif/presentation-3": "1.x"
@@ -262,7 +260,7 @@
         "svg-arc-to-cubic-bezier": "^3.2.0"
       },
       "peerDependencies": {
-        "@atlas-viewer/iiif-image-api": "^2.1.1",
+        "@atlas-viewer/iiif-image-api": "2.x",
         "@iiif/vault": "0.9.x"
       }
     },
@@ -1628,25 +1626,6 @@
         "swiper": "^8.4.5"
       }
     },
-    "node_modules/@samvera/bloom-iiif/node_modules/@iiif/vault-helpers": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.9.11.tgz",
-      "integrity": "sha512-4XuFPvu233mMzfU/mMpAqFY5aCTzwhJ0u7MzPcpN8nSfMwbV5Dyvv0PppjcocvbWMUUXScqerRoB1MAfSFas6w==",
-      "dependencies": {
-        "@iiif/presentation-2": "1.x",
-        "@iiif/presentation-3": "1.x"
-      },
-      "optionalDependencies": {
-        "abs-svg-path": "^0.1.0",
-        "parse-svg-path": "^0.1.0",
-        "react-i18next": "^11.18.0",
-        "svg-arc-to-cubic-bezier": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@atlas-viewer/iiif-image-api": "2.x",
-        "@iiif/vault": "0.9.x"
-      }
-    },
     "node_modules/@samvera/bloom-iiif/node_modules/@samvera/nectar-iiif": {
       "version": "0.0.18",
       "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.18.tgz",
@@ -1704,25 +1683,6 @@
         "react-dom": "^16.13.1  || ^17 || ^18",
         "react-error-boundary": "^3.1.4",
         "uuid": "^9.0.0"
-      }
-    },
-    "node_modules/@samvera/clover-iiif/node_modules/@iiif/vault-helpers": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.9.11.tgz",
-      "integrity": "sha512-4XuFPvu233mMzfU/mMpAqFY5aCTzwhJ0u7MzPcpN8nSfMwbV5Dyvv0PppjcocvbWMUUXScqerRoB1MAfSFas6w==",
-      "dependencies": {
-        "@iiif/presentation-2": "1.x",
-        "@iiif/presentation-3": "1.x"
-      },
-      "optionalDependencies": {
-        "abs-svg-path": "^0.1.0",
-        "parse-svg-path": "^0.1.0",
-        "react-i18next": "^11.18.0",
-        "svg-arc-to-cubic-bezier": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@atlas-viewer/iiif-image-api": "2.x",
-        "@iiif/vault": "0.9.x"
       }
     },
     "node_modules/@samvera/clover-iiif/node_modules/@samvera/nectar-iiif": {
@@ -8027,9 +7987,9 @@
       }
     },
     "@iiif/vault-helpers": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.10.0.tgz",
-      "integrity": "sha512-gnjTPcZJMIDjwU5K8HYNU8Iix49Awmsr7IhIyxA5ZCqugnLjHvJUOmOvT7q1NRd6ia4+09wxx+EMH0D9mt4cxQ==",
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.9.11.tgz",
+      "integrity": "sha512-4XuFPvu233mMzfU/mMpAqFY5aCTzwhJ0u7MzPcpN8nSfMwbV5Dyvv0PppjcocvbWMUUXScqerRoB1MAfSFas6w==",
       "requires": {
         "@iiif/presentation-2": "1.x",
         "@iiif/presentation-3": "1.x",
@@ -9018,19 +8978,6 @@
         "swiper": "^8.4.5"
       },
       "dependencies": {
-        "@iiif/vault-helpers": {
-          "version": "0.9.11",
-          "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.9.11.tgz",
-          "integrity": "sha512-4XuFPvu233mMzfU/mMpAqFY5aCTzwhJ0u7MzPcpN8nSfMwbV5Dyvv0PppjcocvbWMUUXScqerRoB1MAfSFas6w==",
-          "requires": {
-            "@iiif/presentation-2": "1.x",
-            "@iiif/presentation-3": "1.x",
-            "abs-svg-path": "^0.1.0",
-            "parse-svg-path": "^0.1.0",
-            "react-i18next": "^11.18.0",
-            "svg-arc-to-cubic-bezier": "^3.2.0"
-          }
-        },
         "@samvera/nectar-iiif": {
           "version": "0.0.18",
           "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.18.tgz",
@@ -9078,19 +9025,6 @@
         "uuid": "^9.0.0"
       },
       "dependencies": {
-        "@iiif/vault-helpers": {
-          "version": "0.9.11",
-          "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.9.11.tgz",
-          "integrity": "sha512-4XuFPvu233mMzfU/mMpAqFY5aCTzwhJ0u7MzPcpN8nSfMwbV5Dyvv0PppjcocvbWMUUXScqerRoB1MAfSFas6w==",
-          "requires": {
-            "@iiif/presentation-2": "1.x",
-            "@iiif/presentation-3": "1.x",
-            "abs-svg-path": "^0.1.0",
-            "parse-svg-path": "^0.1.0",
-            "react-i18next": "^11.18.0",
-            "svg-arc-to-cubic-bezier": "^3.2.0"
-          }
-        },
         "@samvera/nectar-iiif": {
           "version": "0.0.18",
           "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.18.tgz",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,6 @@
   },
   "dependencies": {
     "@iiif/parser": "^1.1.2",
-    "@iiif/vault": "^0.9.22",
-    "@iiif/vault-helpers": "^0.10.0",
     "@mdx-js/loader": "^2.3.0",
     "@next/mdx": "^13.2.3",
     "@radix-ui/colors": "^0.1.8",

--- a/package.json
+++ b/package.json
@@ -14,25 +14,23 @@
   "dependencies": {
     "@iiif/parser": "^1.1.2",
     "@iiif/vault": "^0.9.22",
-    "@iiif/vault-helpers": "^0.9.11",
+    "@iiif/vault-helpers": "^0.10.0",
     "@mdx-js/loader": "^2.3.0",
     "@next/mdx": "^13.2.3",
     "@radix-ui/colors": "^0.1.8",
-    "@radix-ui/react-accordion": "^1.1.0",
+    "@radix-ui/react-accordion": "^1.1.1",
     "@radix-ui/react-checkbox": "^1.0.1",
     "@radix-ui/react-dialog": "^1.0.2",
     "@radix-ui/react-icons": "^1.1.1",
-    "@radix-ui/react-scroll-area": "^1.0.2",
-    "@radix-ui/react-select": "^1.1.2",
     "@samvera/bloom-iiif": "^0.5.0",
-    "@samvera/clover-iiif": "^1.13.2",
+    "@samvera/clover-iiif": "^1.14.1",
     "@samvera/nectar-iiif": "^0.0.20",
     "@stitches/react": "^1.2.8",
     "axios": "^0.24.0",
     "clsx": "^1.1.1",
     "copy-to-clipboard": "^3.3.3",
     "flexsearch": "^0.7.31",
-    "framer-motion": "^8.5.4",
+    "framer-motion": "^10.9.4",
     "leaflet": "^1.9.3",
     "lodash": "^4.17.21",
     "next": "^13.0.0",
@@ -45,7 +43,7 @@
     "react-leaflet": "^4.2.0",
     "react-masonry-css": "^1.0.16",
     "slugify": "^1.6.3",
-    "swiper": "^8.4.4"
+    "swiper": "^9.1.1"
   },
   "devDependencies": {
     "@iiif/presentation-3": "^1.1.3",
@@ -60,6 +58,6 @@
     "eslint-config-next": "^13.1.1",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-testing-library": "^5.2.1",
-    "typescript": "^4.9.3"
+    "typescript": "^5.0.2"
   }
 }

--- a/pages/works/[slug].tsx
+++ b/pages/works/[slug].tsx
@@ -3,9 +3,9 @@ import Viewer from "@/components/Viewer/Viewer";
 // import Related from "@/components/Related/Related";
 import WorkInner from "@/components/Work/Inner";
 import MANIFESTS from "@/.canopy/manifests.json";
-import { Vault } from "@iiif/vault";
-import Container from "../../components/Shared/Container";
+import Container from "@/components/Shared/Container";
 import { Manifest } from "@iiif/presentation-3";
+import { upgrade } from "@iiif/parser/upgrader";
 
 interface WorkProps {
   manifest: Manifest;
@@ -27,13 +27,9 @@ export default function Work({ manifest }: WorkProps) {
 
 export async function getStaticProps({ params }: { params: any }) {
   const { id } = MANIFESTS.find((item) => item.slug === params.slug) as any;
-  const vault = new Vault();
-  const manifest = await vault
-    .loadManifest(id)
-    .then((data) => data)
-    .catch((error) => {
-      console.error(`Manifest ${id} failed to load: ${error}`);
-    });
+  const manifest = await fetch(id)
+    .then((response) => response.json())
+    .then(upgrade);
 
   return {
     props: { manifest },


### PR DESCRIPTION
# What does this do?

This is maintenance work to upgrade packages and prune out unnecessary ones.

 - Vault and Vault Helpers have been removed. We now use `@iiif/parser/upgrade` to handle the post-fetch conversion from Presentation 2.x to Presentation 3.0. This should be a bit lighter as we don't need the Vaulty bells and whistles.
 - Clover has been updated, now supporting `placeholderCanvas` along with a few small bug fixes.
 - Swiper was updated and  small type issue was addressed there.
 - Other package updates are routine maintenance.

## What type of change is this?

- [ ] 🐛 **Bug fix** (non-breaking change addressing an issue)
- [ ] ✨ **New feature or enhancement** (non-breaking change which adds functionality)
- [ ] 🧨 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚧 **Maintenance or refinement of codebase structur**e (ex: dependency updates)
- [ ] 📘 **Documentation update**
