### PR TITLE
Improve basic norwegian translation

### DIFF
--- a/config/locales/nb_NO.json
+++ b/config/locales/nb_NO.json
@@ -1,0 +1,12 @@
+{
+  "footerSourceCollection": "Kildesamling",
+  "footerToggleTheme": "Skift tema",
+  "homepageHighlightedWorks": "Fremhevete verk",
+  "searchButton": "Søk",
+  "searchResults": "resultat",
+  "searchFilter": "Filter",
+  "searchFilterAny": "Alle",
+  "searchFilterClear": "Fjern filter",
+  "searchFilterClose": "Lukk",
+  "searchFilterSubmit": "Se treff"
+}

--- a/config/locales/nn_NO.json
+++ b/config/locales/nn_NO.json
@@ -1,0 +1,12 @@
+{
+  "footerSourceCollection": "Kjeldesamling",
+  "footerToggleTheme": "Endre tema",
+  "homepageHighlightedWorks": "Framheva verk",
+  "searchButton": "Søk",
+  "searchResults": "resultat",
+  "searchFilter": "Filter",
+  "searchFilterAny": "Alle",
+  "searchFilterClear": "Fjern filter",
+  "searchFilterClose": "Lukk",
+  "searchFilterSubmit": "Sjå treffa"
+}

--- a/config/locales/no.json
+++ b/config/locales/no.json
@@ -1,12 +1,12 @@
 {
   "footerSourceCollection": "Kildesamling",
-  "footerToggleTheme": "Slå av/på tema",
-  "homepageHighlightedWorks": "Uthevede verk",
+  "footerToggleTheme": "Skift tema",
+  "homepageHighlightedWorks": "Fremhevete verk",
   "searchButton": "Søk",
-  "searchResults": "Resultater",
-  "searchFilter": "Raffinere",
-  "searchFilterAny": "Noen",
-  "searchFilterClear": "Rydd alt",
+  "searchResults": "resultat",
+  "searchFilter": "Filter",
+  "searchFilterAny": "Alle",
+  "searchFilterClear": "Fjern filter",
   "searchFilterClose": "Lukk",
-  "searchFilterSubmit": "Se resultater"
+  "searchFilterSubmit": "Se treff"
 }


### PR DESCRIPTION
# What does this do?

Improve the Norwegian translation of the basic UI. Add `nb_NO.json` and `nn_NO.json`, since Norwegian is one spoken language, but with two written forms.

Related to #18, #20.

## What type of change is this?

- [ ] 🐛 **Bug fix** (non-breaking change addressing an issue)
- [x] ✨ **New feature or enhancement** (non-breaking change which adds functionality)
- [ ] 🧨 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚧 **Maintenance or refinement of codebase structur**e (ex: dependency updates)
- [ ] 📘 **Documentation update**

## Additional Notes

Norwegian is bit of a complicated language. It is one language with two equal written forms, Bokmål and Nynorsk. `no` is often the default and uses in most cases "bokmål". `nb_NO` (bokmål) and `nn_NO` (nynorsk) would be the precise language codes to use. `no` is therefore more precisely `nb_NO`. 
So, sorry @mathewjordan, Norwegian is one of the more annoying languages to translate... Kept `no`, as it might be needed for browser language detection later?