### PR TITLE
Breakout FlexSearch configuration to options.json.

### DIFF
--- a/config/.default/options.default.json
+++ b/config/.default/options.default.json
@@ -38,6 +38,31 @@
   },
   "search": {
     "enabled": true,
+    "flexSearch": {
+      "charset": "latin:extra",
+      "optimize": true,
+      "tokenize": "strict",
+      "bidirectional": false,
+      "document": {
+        "index": [
+          {
+            "field": "label",
+            "tokenize": "full",
+            "resolution": 9,
+            "depth": 3,
+            "bidirectional": true
+          },
+          {
+            "field": "metadata",
+            "resolution": 2
+          },
+          {
+            "field": "summary",
+            "resolution": 1
+          }
+        ]
+      }
+    },
     "index": {
       "metadata": {
         "enabled": true,

--- a/config/options.sample.json
+++ b/config/options.sample.json
@@ -38,6 +38,31 @@
   },
   "search": {
     "enabled": true,
+    "flexSearch": {
+      "charset": "latin:extra",
+      "optimize": true,
+      "tokenize": "strict",
+      "bidirectional": false,
+      "document": {
+        "index": [
+          {
+            "field": "label",
+            "tokenize": "full",
+            "resolution": 9,
+            "depth": 3,
+            "bidirectional": true
+          },
+          {
+            "field": "metadata",
+            "resolution": 2
+          },
+          {
+            "field": "summary",
+            "resolution": 1
+          }
+        ]
+      }
+    },
     "index": {
       "metadata": {
         "enabled": true,

--- a/pages/about/documentation.mdx
+++ b/pages/about/documentation.mdx
@@ -148,16 +148,7 @@ Users can customize their [FlexSearch configuration](https://github.com/nextapps
 ```json
 "search": {
   "enabled": true,
-  "index": {
-    "metadata": {
-      "enabled": true,
-      "all": false
-     },
-    "summary": {
-      "enabled": false
-     }
-  },
-  flexSearch: {
+  "flexSearch": {
     "charset": "latin:extra",
     "optimize": true,
     "tokenize": "strict",
@@ -181,6 +172,15 @@ Users can customize their [FlexSearch configuration](https://github.com/nextapps
         }
       ]
     }
+  },
+  "index": {
+    "metadata": {
+      "enabled": true,
+      "all": false
+     },
+    "summary": {
+      "enabled": false
+     }
   }
 }
 ```

--- a/pages/about/documentation.mdx
+++ b/pages/about/documentation.mdx
@@ -139,6 +139,12 @@ Search options can be configured in `config/options.json`. By default, the searc
 
 The only property that can be indexed outside of `metadata` and `label` currently is `summary`. This is configured with `search.index.summary.enabled` .
 
+#### FlexSearch
+
+Users can customize their [FlexSearch configuration](https://github.com/nextapps-de/flexsearch#options) using `search.flexSearch` to fit around the source Collection and its Manifest `label`, `metadata`, and `summary` properties. Customizations range from defining language-specific options such as `charset` and `stemmer`, as well as scoring options like `resolution` and `depth`.
+
+#### Default Search Configuration
+
 ```json
 "search": {
   "enabled": true,
@@ -150,6 +156,31 @@ The only property that can be indexed outside of `metadata` and `label` currentl
     "summary": {
       "enabled": false
      }
+  },
+  flexSearch: {
+    "charset": "latin:extra",
+    "optimize": true,
+    "tokenize": "strict",
+    "bidirectional": false,
+    "document": {
+      "index": [
+        {
+          "field": "label",
+          "tokenize": "full",
+          "resolution": 9,
+          "depth": 3,
+          "bidirectional": true
+        },
+        {
+          "field": "metadata",
+          "resolution": 2
+        },
+        {
+          "field": "summary",
+          "resolution": 1
+        }
+      ]
+    }
   }
 }
 ```

--- a/services/search/documents.ts
+++ b/services/search/documents.ts
@@ -1,38 +1,14 @@
+// @ts-nocheck
+
 import INDEX from "@/.canopy/index.json";
 import { Document } from "flexsearch";
 
 const getDocuments = (q: string) => {
-  //@ts-ignore
-  const index = new Document({
-    charset: "latin:extra",
-    optimize: true,
-    tokenize: "strict",
-    bidirectional: false,
-    document: {
-      index: [
-        {
-          field: "label",
-          tokenize: "extra",
-          resolution: 9,
-          depth: 3,
-          bidirectional: true,
-        },
-        {
-          field: "metadata",
-          resolution: 2,
-        },
-        {
-          field: "summary",
-          resolution: 1,
-        },
-      ],
-    },
-  });
+  const { flexSearch } = process.env?.CANOPY_CONFIG?.search;
 
-  //@ts-ignore
+  const index = new Document(flexSearch);
   INDEX.forEach((doc) => index.add(doc));
 
-  //@ts-ignore
   const results = index.search(q).reduce((acc, curr) => {
     return [...new Set([...acc, ...curr.result])];
   }, []);

--- a/types/canopy.ts
+++ b/types/canopy.ts
@@ -1,5 +1,4 @@
 import { InternationalString } from "@iiif/presentation-3";
-import {} from "flexsearch";
 
 export interface CanopyCollectionShape {
   "@context": string;

--- a/types/canopy.ts
+++ b/types/canopy.ts
@@ -1,4 +1,5 @@
 import { InternationalString } from "@iiif/presentation-3";
+import {} from "flexsearch";
 
 export interface CanopyCollectionShape {
   "@context": string;
@@ -35,6 +36,7 @@ export interface CanopyEnvironment {
       metadata: { enabled: boolean; all: boolean };
       summary: { enabled: boolean };
     };
+    flexSearch: any;
   };
   static: boolean;
   theme: { defaultTheme: string; toggleEnabled: boolean };


### PR DESCRIPTION
# What does this do?

This update the configuration FlexSearch to be centralized in the options.json `search.flexSearch` property. Doing this makes the FlexSearch configuration easily customizable by the end user without needing to touch any core canopy code.

I additionally created basic documentation for this.

## What type of change is this?

- [ ] 🐛 **Bug fix** (non-breaking change addressing an issue)
- [ ] ✨ **New feature or enhancement** (non-breaking change which adds functionality)
- [ ] 🧨 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚧 **Maintenance or refinement of codebase structur**e (ex: dependency updates)
- [ ] 📘 **Documentation update**
