### PR TITLE
Add max-height to IIIF Manifest HTML markup <img/>.

### DIFF
--- a/components/Work/Inner.styled.ts
+++ b/components/Work/Inner.styled.ts
@@ -21,11 +21,11 @@ const StyledWorkInner = styled("section", {
 
   "dl, .work-summary": {
     img: {
-      maxHeight: "3rem !important",
+      maxHeight: "$gr5 !important",
       margin: "$gr1 0",
 
       "@sm": {
-        maxHeight: "2rem !important",
+        maxHeight: "$gr4 !important",
       },
     },
   },

--- a/components/Work/Inner.styled.ts
+++ b/components/Work/Inner.styled.ts
@@ -18,6 +18,17 @@ const StyledWorkInner = styled("section", {
       marginBottom: "$gr4",
     },
   },
+
+  "dl, .work-summary": {
+    img: {
+      maxHeight: "3rem !important",
+      margin: "$gr1 0",
+
+      "@sm": {
+        maxHeight: "2rem !important",
+      },
+    },
+  },
 });
 
 export { StyledWorkInner, WorkData };


### PR DESCRIPTION
# What does this do?

This adds a max-height (relative to the global rem) to any rendered HTML markup `<img/>` within a IIIF Manifest. This accounts for `summary`, `metadata`, and `requiredStatement` properties according to https://iiif.io/api/presentation/3.0/#45-html-markup-in-property-values.

## What type of change is this?

- [ ] 🐛 **Bug fix** (non-breaking change addressing an issue)
- [ ] ✨ **New feature or enhancement** (non-breaking change which adds functionality)
- [ ] 🧨 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚧 **Maintenance or refinement of codebase structur**e (ex: dependency updates)
- [ ] 📘 **Documentation update**
