### PR TITLE
Add Related component to work page.

### DIFF
--- a/pages/works/[slug].tsx
+++ b/pages/works/[slug].tsx
@@ -1,17 +1,20 @@
 import Layout from "@/components/layout";
 import Viewer from "@/components/Viewer/Viewer";
-// import Related from "@/components/Related/Related";
+import Related from "@/components/Related/Related";
 import WorkInner from "@/components/Work/Inner";
+import FACETS from "@/.canopy/facets.json";
 import MANIFESTS from "@/.canopy/manifests.json";
 import Container from "@/components/Shared/Container";
 import { Manifest } from "@iiif/presentation-3";
 import { fetch } from "@iiif/vault-helpers/fetch";
+import { shuffle } from "lodash";
 
 interface WorkProps {
   manifest: Manifest;
+  related: any;
 }
 
-export default function Work({ manifest }: WorkProps) {
+export default function Work({ manifest, related }: WorkProps) {
   const { id } = manifest;
 
   return (
@@ -19,15 +22,24 @@ export default function Work({ manifest }: WorkProps) {
       <Viewer id={id} />
       <Container>
         <WorkInner manifest={manifest} />
-        {/* <Related collections={collections} /> */}
+        <Related collections={related} />
       </Container>
     </Layout>
   );
 }
 
 export async function getStaticProps({ params }: { params: any }) {
-  const { id } = MANIFESTS.find((item) => item.slug === params.slug) as any;
+  const { id, index } = MANIFESTS.find(
+    (item) => item.slug === params.slug
+  ) as any;
   const manifest = await fetch(id);
+
+  const related = FACETS.map((facet) => {
+    const value = shuffle(
+      facet.values.filter((entry) => entry.docs.includes(index))
+    );
+    return `/api/facet/${facet.slug}/${value[0]?.slug}?sort=random`;
+  });
 
   /**
    * scrub the manifest of any provider property
@@ -35,7 +47,7 @@ export async function getStaticProps({ params }: { params: any }) {
   delete manifest.provider;
 
   return {
-    props: { manifest },
+    props: { manifest, related },
   };
 }
 


### PR DESCRIPTION
# What does this do?

This work adds the Related component to the subfooter of a `/works` page, rendering Bloom sliders sourced internal facet API routes that return IIIF Collections. 

![image](https://github.com/mathewjordan/canopy-iiif/assets/7376450/d98049cb-602f-4af8-b5cb-b1e41c426abb)

## What type of change is this?

- [ ] 🐛 **Bug fix** (non-breaking change addressing an issue)
- [x] ✨ **New feature or enhancement** (non-breaking change which adds functionality)
- [ ] 🧨 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚧 **Maintenance or refinement of codebase structure (ex: dependency updates)
- [ ] 📘 **Documentation update**

