### PR TITLE
Add baseline OpenGraph meta properties.

### DIFF
--- a/config/.default/canopy.default.json
+++ b/config/.default/canopy.default.json
@@ -1,6 +1,11 @@
 {
   "prod": {
     "label": { "none": ["Canopy IIIF"] },
+    "summary": {
+      "none": [
+        "a IIIF Collection sourced site generator in Next.js for digital collections, humanities, and exhibitions"
+      ]
+    },
     "collection": "https://digital.lib.utk.edu/assemble/collection/gsmrc/wcc",
     "featured": [
       "https://digital.lib.utk.edu/assemble/manifest/wcc/350",
@@ -11,6 +16,11 @@
   },
   "dev": {
     "label": { "none": ["Canopy IIIF"] },
+    "summary": {
+      "none": [
+        "a IIIF Collection sourced site generator in Next.js for digital collections, humanities, and exhibitions"
+      ]
+    },
     "collection": "https://digital.lib.utk.edu/assemble/collection/gsmrc/wcc",
     "featured": [
       "https://digital.lib.utk.edu/assemble/manifest/wcc/350",

--- a/config/.default/options.default.json
+++ b/config/.default/options.default.json
@@ -1,4 +1,5 @@
 {
+  "url": "https://canopy-iiif.vercel.app",
   "locales": [
     {
       "config": "locales/en.json",

--- a/config/canopy.sample.json
+++ b/config/canopy.sample.json
@@ -2,9 +2,7 @@
   "prod": {
     "label": { "none": ["Collection Title"] },
     "summary": {
-      "none": [
-        "a IIIF Collection sourced site generator in Next.js for digital collections, humanities, and exhibitions"
-      ]
+      "none": ["Brief description of the site and its contents."]
     },
     "collection": "https://example.org/iiif/collection.json",
     "featured": [
@@ -16,9 +14,7 @@
   "dev": {
     "label": { "none": ["Collection Title"] },
     "summary": {
-      "none": [
-        "a IIIF Collection sourced site generator in Next.js for digital collections, humanities, and exhibitions"
-      ]
+      "none": ["Brief description of the site and its contents."]
     },
     "collection": "https://example.org/iiif/collection.json",
     "featured": [

--- a/config/canopy.sample.json
+++ b/config/canopy.sample.json
@@ -1,6 +1,11 @@
 {
   "prod": {
     "label": { "none": ["Collection Title"] },
+    "summary": {
+      "none": [
+        "a IIIF Collection sourced site generator in Next.js for digital collections, humanities, and exhibitions"
+      ]
+    },
     "collection": "https://example.org/iiif/collection.json",
     "featured": [
       "https://example.org/manifest-1.json",
@@ -10,6 +15,11 @@
   },
   "dev": {
     "label": { "none": ["Collection Title"] },
+    "summary": {
+      "none": [
+        "a IIIF Collection sourced site generator in Next.js for digital collections, humanities, and exhibitions"
+      ]
+    },
     "collection": "https://example.org/iiif/collection.json",
     "featured": [
       "https://example.org/manifest-1.json",

--- a/config/options.sample.json
+++ b/config/options.sample.json
@@ -1,4 +1,5 @@
 {
+  "url": "https://canopy-iiif.vercel.app",
   "locales": [
     {
       "config": "locales/en.json",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "lodash": "^4.17.21",
         "next": "^13.0.0",
         "next-absolute-url": "^1.2.2",
+        "next-seo": "^6.0.0",
         "next-themes": "^0.2.1",
         "prism-react-renderer": "^1.3.5",
         "react": "^18.2.0",
@@ -6136,6 +6137,16 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/next-absolute-url/-/next-absolute-url-1.2.2.tgz",
       "integrity": "sha512-Z2+LZXQTthhw2je9u4eq8QWXxXd57a6b54x9exBfQX4Dct6YxaMjcXZWNLHd9AOlCue84EsMpdSGP7wACqUnPg=="
+    },
+    "node_modules/next-seo": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/next-seo/-/next-seo-6.0.0.tgz",
+      "integrity": "sha512-jKKt1p1z4otMA28AyeoAONixVjdYmgFCWwpEFtu+DwRHQDllVX3RjtyXbuCQiUZEfQ9rFPBpAI90vDeLZlMBdg==",
+      "peerDependencies": {
+        "next": "^8.1.1-canary.54 || >=9.0.0",
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
     },
     "node_modules/next-themes": {
       "version": "0.2.1",
@@ -12374,6 +12385,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/next-absolute-url/-/next-absolute-url-1.2.2.tgz",
       "integrity": "sha512-Z2+LZXQTthhw2je9u4eq8QWXxXd57a6b54x9exBfQX4Dct6YxaMjcXZWNLHd9AOlCue84EsMpdSGP7wACqUnPg=="
+    },
+    "next-seo": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/next-seo/-/next-seo-6.0.0.tgz",
+      "integrity": "sha512-jKKt1p1z4otMA28AyeoAONixVjdYmgFCWwpEFtu+DwRHQDllVX3RjtyXbuCQiUZEfQ9rFPBpAI90vDeLZlMBdg==",
+      "requires": {}
     },
     "next-themes": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lodash": "^4.17.21",
     "next": "^13.0.0",
     "next-absolute-url": "^1.2.2",
+    "next-seo": "^6.0.0",
     "next-themes": "^0.2.1",
     "prism-react-renderer": "^1.3.5",
     "react": "^18.2.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,6 +7,8 @@ import { AppProps } from "next/app";
 import { ObjectLiteral } from "@/types";
 import { getDefaultLang, getLocale } from "@/hooks/useLocale";
 import { CanopyEnvironment, CanopyLocale } from "@/types/canopy";
+import { NextSeo } from "next-seo";
+import { buildDefaultSEO } from "@/services/seo";
 
 interface CanopyAppProps extends AppProps {
   pageProps: ObjectLiteral;
@@ -20,11 +22,14 @@ export default function CanopyAppProps({
 
   const config = process.env.CANOPY_CONFIG as unknown as CanopyEnvironment;
   const { locales, theme } = config;
+  const seo = pageProps.seo ? pageProps.seo : buildDefaultSEO(config);
 
-  const [mounted, setMounted] = useState(false);
   const [locale, setLocale] = useState<CanopyLocale>();
+  const [mounted, setMounted] = useState(false);
 
-  useEffect(() => setMounted(true), []);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     if (mounted && !locale) {
@@ -37,25 +42,28 @@ export default function CanopyAppProps({
   }, [locale, locales, mounted]);
 
   return (
-    <ThemeProvider
-      attribute="class"
-      defaultTheme={theme.defaultTheme ? theme.defaultTheme : "light"}
-      value={{
-        dark: darkTheme.className,
-        light: "light",
-      }}
-    >
-      {locale && (
-        <CanopyProvider
-          initialState={{
-            ...defaultState,
-            config: config,
-            locale: locale,
-          }}
-        >
-          {mounted && <Component {...pageProps} />}
-        </CanopyProvider>
-      )}
-    </ThemeProvider>
+    <>
+      <NextSeo {...seo} />
+      <ThemeProvider
+        attribute="class"
+        defaultTheme={theme.defaultTheme ? theme.defaultTheme : "light"}
+        value={{
+          dark: darkTheme.className,
+          light: "light",
+        }}
+      >
+        {locale && (
+          <CanopyProvider
+            initialState={{
+              ...defaultState,
+              config: config,
+              locale: locale,
+            }}
+          >
+            {mounted && <Component {...pageProps} />}
+          </CanopyProvider>
+        )}
+      </ThemeProvider>
+    </>
   );
 }

--- a/pages/about/documentation.mdx
+++ b/pages/about/documentation.mdx
@@ -46,6 +46,7 @@ Both the prod and dev environments have a configuration. These configurations ca
 {
   "prod": {
     "label": { "none": ["Hobhouse"] },
+    "summary": { "none": ["Manuscripts from the archive of Emily Hobhouse."] },
     "collection": "https://iiif.bodleian.ox.ac.uk/iiif/collection/hobhouse",
     "featured": [
       "https://iiif.bodleian.ox.ac.uk/iiif/manifest/8da97e8c-4e12-457d-aad8-3327b3aec183.json",
@@ -55,6 +56,7 @@ Both the prod and dev environments have a configuration. These configurations ca
   },
   "dev": {
     "label": { "none": ["Hobhouse"] },
+    "summary": { "none": ["Manuscripts from the archive of Emily Hobhouse."] },
     "collection": "https://iiif.bodleian.ox.ac.uk/iiif/collection/hobhouse",
     "featured": [
       "https://iiif.bodleian.ox.ac.uk/iiif/manifest/8da97e8c-4e12-457d-aad8-3327b3aec183.json",
@@ -67,12 +69,15 @@ Both the prod and dev environments have a configuration. These configurations ca
 
 ## Customization
 
-### Site Title
+### Site Title and Description
 
-The Canopy IIIF site title is the Collection `label` of the set collection resource. You can optionally override this by providing a valid [Presentation 3.0 label](https://iiif.io/api/presentation/3.0/#label) property.
+The Canopy IIIF site title and description are respectively the `label` and `summary` of the set Collection resource. You can optionally override this by providing a valid Presentation 3.0 [label](https://iiif.io/api/presentation/3.0/#label) and/or [summary](https://iiif.io/api/presentation/3.0/#summary) property.
 
 ```json
-"label": { "none": ["Hobhouse"] }
+{
+  "label": { "none": ["Hobhouse"] },
+  "summary": { "none": ["Manuscripts from the archive of Emily Hobhouse."] }
+}
 ```
 
 ### Featured Manifests

--- a/pages/works/[slug].tsx
+++ b/pages/works/[slug].tsx
@@ -8,6 +8,7 @@ import Container from "@/components/Shared/Container";
 import { Manifest } from "@iiif/presentation-3";
 import { fetch } from "@iiif/vault-helpers/fetch";
 import { shuffle } from "lodash";
+import { buildManifestSEO } from "@/services/seo";
 
 interface WorkProps {
   manifest: Manifest;
@@ -32,7 +33,12 @@ export async function getStaticProps({ params }: { params: any }) {
   const { id, index } = MANIFESTS.find(
     (item) => item.slug === params.slug
   ) as any;
-  const manifest = await fetch(id);
+  const manifest = (await fetch(id)) as Manifest;
+
+  /**
+   * build the seo object
+   */
+  const seo = await buildManifestSEO(manifest, `/works/${params.slug}`);
 
   const related = FACETS.map((facet) => {
     const value = shuffle(
@@ -47,7 +53,7 @@ export async function getStaticProps({ params }: { params: any }) {
   delete manifest.provider;
 
   return {
-    props: { manifest, related },
+    props: { manifest, related, seo },
   };
 }
 

--- a/services/build/aggregate.js
+++ b/services/build/aggregate.js
@@ -16,6 +16,7 @@ module.exports.build = (env) => {
     const canopyCollection = getCanopyCollection({
       ...json,
       label: env.label ? env.label : json.label,
+      summary: env.summary ? env.summary : json.summary,
     });
 
     try {

--- a/services/iiif/image.js
+++ b/services/iiif/image.js
@@ -1,6 +1,6 @@
 const axios = require("axios");
 
-const getService = async (service, preferredWidth = 1000) => {
+const getService = async (service, preferredWidth = 1200) => {
   if (service.hasOwnProperty("@id")) {
     try {
       const response = await axios.get(`${service["@id"]}/info.json`);
@@ -22,7 +22,7 @@ const getService = async (service, preferredWidth = 1000) => {
   }
 };
 
-exports.getRepresentativeImage = async (resource, preferredSize = 1000) => {
+exports.getRepresentativeImage = async (resource, preferredSize = 1200) => {
   const firstCanvas = resource.items[0].items[0].items[0];
   const firstCanvasService = await getService(
     firstCanvas.body.service[0],

--- a/services/seo.ts
+++ b/services/seo.ts
@@ -1,0 +1,62 @@
+import { CanopyEnvironment } from "@/types/canopy";
+import MANIFESTS from "@/.canopy/manifests.json";
+import { Manifest } from "@iiif/presentation-3";
+import { getLabel } from "./iiif/label";
+import { getRepresentativeImage } from "./iiif/image";
+
+const buildManifestSEO = async (manifest: Manifest, path: string) => {
+  const { url, label } = process.env
+    ?.CANOPY_CONFIG as unknown as CanopyEnvironment;
+  const images = await getRepresentativeImage(manifest);
+  const title = getLabel(manifest.label).join(" - ");
+
+  return {
+    title: `${title} - ${getLabel(label).join(" - ")}`,
+    description: getLabel(manifest.summary).join(" - "),
+    canonical: `${url}${path}`,
+    openGraph: {
+      images: images.map((item: any) => {
+        return {
+          url: item.id,
+          type: item.format,
+          width: item.width,
+          height: item.height,
+          alt: title,
+        };
+      }),
+    },
+  };
+};
+
+const buildDefaultSEO = (config: any) => {
+  const title = getLabel(config.label).join(" - ");
+  const description = getLabel(config.summary).join(" - ");
+  const featured = config.featured;
+
+  const images = featured
+    .map((item: any) => {
+      const manifest = MANIFESTS.find((manifest: any) => manifest?.id === item);
+      return manifest?.thumbnail[0];
+    })
+    .filter((item: any) => item);
+
+  return {
+    title,
+    description,
+    openGraph: {
+      images: images.map((item: any) => {
+        if (!item) return;
+
+        return {
+          url: item?.id,
+          type: item?.format,
+          width: item?.width,
+          height: item?.height,
+          alt: title,
+        };
+      }),
+    },
+  };
+};
+
+export { buildDefaultSEO, buildManifestSEO };

--- a/types/canopy.ts
+++ b/types/canopy.ts
@@ -23,9 +23,9 @@ export interface CanopyCollectionShape {
 }
 
 export interface CanopyEnvironment {
-  label: InternationalString;
   collection: string;
   featured: string[];
+  label: InternationalString;
   locales: CanopyLocale[];
   metadata: string[];
   map: { enabled: boolean };
@@ -38,7 +38,9 @@ export interface CanopyEnvironment {
     flexSearch: any;
   };
   static: boolean;
+  summary: InternationalString;
   theme: { defaultTheme: string; toggleEnabled: boolean };
+  url: string;
 }
 
 export interface CanopyFacetValueShape {


### PR DESCRIPTION
# What does this do?

This adds basic SEO coverage across all page routes in Canopy. As of right now, the `/work/...` routes will have unique properties built from the respective Manifest and all other routes will use a default that is sourced from baseline configuration information for the label, summary, and featured canopy.json properties.

I feel this work can be iterative and we can expand on default as needed.

![image](https://github.com/mathewjordan/canopy-iiif/assets/7376450/dfeaf2e4-3edd-43ad-9fd7-e54ccc37c8c0)

![image](https://github.com/mathewjordan/canopy-iiif/assets/7376450/6b6440a7-5a24-4b95-990e-76632b5cf16e)

![image](https://github.com/mathewjordan/canopy-iiif/assets/7376450/b053cdeb-5aa1-4a56-adea-b526e1dc3d20)


## What type of change is this?

- [ ] 🐛 **Bug fix** (non-breaking change addressing an issue)
- [x] ✨ **New feature or enhancement** (non-breaking change which adds functionality)
- [ ] 🧨 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚧 **Maintenance or refinement of codebase structur**e (ex: dependency updates)
- [ ] 📘 **Documentation update**
